### PR TITLE
feat: add messages module for threads and confidentiality

### DIFF
--- a/src/modules/messages/repository.ts
+++ b/src/modules/messages/repository.ts
@@ -1,0 +1,307 @@
+import { randomUUID } from 'crypto';
+import type { PoolClient } from 'pg';
+import { query, withTransaction } from '../../db';
+import { AppError } from '../../shared/errors';
+
+export type ThreadVisibility = 'internal' | 'project' | 'private';
+export type MessageVisibility = 'internal' | 'project' | 'private';
+
+export type ThreadMemberRecord = {
+  id: string;
+  name: string | null;
+};
+
+export type ThreadRecord = {
+  id: string;
+  scope: string;
+  subject: string | null;
+  visibility: ThreadVisibility;
+  createdAt: string;
+  createdBy: {
+    id: string;
+    name: string | null;
+  };
+  members: ThreadMemberRecord[];
+};
+
+export type MessageRecord = {
+  id: string;
+  threadId: string;
+  author: {
+    id: string;
+    name: string | null;
+  };
+  body: string;
+  visibility: MessageVisibility;
+  isConfidential: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function toIso(value: unknown): string {
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}
+
+function mapThreadRow(row: any): ThreadRecord {
+  return {
+    id: row.id,
+    scope: row.scope,
+    subject: row.subject ?? null,
+    visibility: (row.visibility ?? 'internal') as ThreadVisibility,
+    createdAt: toIso(row.created_at),
+    createdBy: {
+      id: row.created_by,
+      name: row.creator_display_name ?? row.creator_name ?? null,
+    },
+    members: [],
+  };
+}
+
+function mapMemberRow(row: any): ThreadMemberRecord {
+  return {
+    id: row.user_id,
+    name: row.member_display_name ?? row.member_name ?? null,
+  };
+}
+
+function mapMessageRow(row: any): MessageRecord {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    author: {
+      id: row.author_id,
+      name: row.author_display_name ?? row.author_name ?? null,
+    },
+    body: row.body,
+    visibility: (row.visibility ?? 'internal') as MessageVisibility,
+    isConfidential: Boolean(row.is_confidential),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+async function loadThreadMembers(threadIds: string[], client?: PoolClient): Promise<Map<string, ThreadMemberRecord[]>> {
+  if (threadIds.length === 0) {
+    return new Map();
+  }
+
+  const placeholders = threadIds.map((_, index) => `$${index + 1}`).join(', ');
+  const sql = `select tm.thread_id,
+            tm.user_id,
+            u.name as member_name,
+            coalesce(up.display_name, u.name) as member_display_name
+       from thread_members tm
+       join users u on u.id = tm.user_id
+  left join user_profiles up on up.user_id = u.id
+      where tm.thread_id in (${placeholders})`;
+  const result = client
+    ? await client.query(sql, threadIds)
+    : await query(sql, threadIds);
+
+  const rows = result.rows;
+  const members = new Map<string, ThreadMemberRecord[]>();
+
+  for (const row of rows) {
+    if (!members.has(row.thread_id)) {
+      members.set(row.thread_id, []);
+    }
+
+    members.get(row.thread_id)!.push(mapMemberRow(row));
+  }
+
+  return members;
+}
+
+export async function ensureUsersExist(userIds: string[]): Promise<void> {
+  const uniqueIds = Array.from(new Set(userIds));
+  if (uniqueIds.length === 0) {
+    return;
+  }
+
+  const placeholders = uniqueIds.map((_, index) => `$${index + 1}`).join(', ');
+  const { rows } = await query<{ id: string }>(
+    `select id from users where id in (${placeholders})`,
+    uniqueIds,
+  );
+
+  if (rows.length !== uniqueIds.length) {
+    const found = new Set(rows.map((row) => row.id));
+    const missing = uniqueIds.filter((id) => !found.has(id));
+    throw new AppError(`Unknown users: ${missing.join(', ')}`, 400);
+  }
+}
+
+export async function createThread(params: {
+  scope: string;
+  subject: string | null;
+  visibility: ThreadVisibility;
+  createdBy: string;
+  memberIds: string[];
+}): Promise<string> {
+  return withTransaction(async (client) => {
+    const threadId = randomUUID();
+    await client.query(
+      `insert into threads (id, scope, created_by, subject, visibility)
+       values ($1, $2, $3, $4, $5)` ,
+      [threadId, params.scope, params.createdBy, params.subject ?? null, params.visibility],
+    );
+    const memberIds = Array.from(new Set([...params.memberIds, params.createdBy]));
+
+    for (const memberId of memberIds) {
+      await client.query(
+        `insert into thread_members (thread_id, user_id)
+         values ($1, $2)
+         on conflict do nothing`,
+        [threadId, memberId],
+      );
+    }
+
+    return threadId;
+  });
+}
+
+export async function listThreadsForUser(userId: string, scope?: string): Promise<ThreadRecord[]> {
+  const values: unknown[] = [userId];
+  const conditions = ['tm.user_id = $1'];
+
+  if (scope) {
+    values.push(scope);
+    conditions.push(`t.scope = $${values.length}`);
+  }
+
+  const { rows } = await query(
+    `select t.id,
+            t.scope,
+            t.subject,
+            t.visibility,
+            t.created_at,
+            t.created_by,
+            creator.name as creator_name,
+            coalesce(cp.display_name, creator.name) as creator_display_name
+       from threads t
+       join thread_members tm on tm.thread_id = t.id
+       join users creator on creator.id = t.created_by
+  left join user_profiles cp on cp.user_id = creator.id
+      where ${conditions.join(' and ')}
+      order by t.created_at desc, t.id desc`,
+    values,
+  );
+
+  const threadIds = rows.map((row: any) => row.id);
+  const members = await loadThreadMembers(threadIds);
+
+  return rows.map((row: any) => {
+    const thread = mapThreadRow(row);
+    thread.members = members.get(row.id) ?? [];
+    return thread;
+  });
+}
+
+export async function getThreadById(threadId: string): Promise<ThreadRecord | null> {
+  const { rows } = await query(
+    `select t.id,
+            t.scope,
+            t.subject,
+            t.visibility,
+            t.created_at,
+            t.created_by,
+            creator.name as creator_name,
+            coalesce(cp.display_name, creator.name) as creator_display_name
+       from threads t
+       join users creator on creator.id = t.created_by
+  left join user_profiles cp on cp.user_id = creator.id
+      where t.id = $1`,
+    [threadId],
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const thread = mapThreadRow(rows[0]);
+  const members = await loadThreadMembers([threadId]);
+  thread.members = members.get(threadId) ?? [];
+  return thread;
+}
+
+export async function isThreadMember(threadId: string, userId: string): Promise<boolean> {
+  const { rows } = await query<{ exists: boolean }>(
+    `select exists(
+       select 1 from thread_members where thread_id = $1 and user_id = $2
+     ) as exists`,
+    [threadId, userId],
+  );
+
+  return rows[0]?.exists ?? false;
+}
+
+export async function listMessages(threadId: string): Promise<MessageRecord[]> {
+  const { rows } = await query(
+    `select m.id,
+            m.thread_id,
+            m.author_id,
+            m.body,
+            m.visibility,
+            m.is_confidential,
+            m.created_at,
+            m.updated_at,
+            u.name as author_name,
+            coalesce(up.display_name, u.name) as author_display_name
+       from messages m
+       join users u on u.id = m.author_id
+  left join user_profiles up on up.user_id = u.id
+      where m.thread_id = $1
+      order by m.created_at asc, m.id asc`,
+    [threadId],
+  );
+
+  return rows.map((row: any) => mapMessageRow(row));
+}
+
+export async function getMessageById(messageId: string): Promise<MessageRecord | null> {
+  const { rows } = await query(
+    `select m.id,
+            m.thread_id,
+            m.author_id,
+            m.body,
+            m.visibility,
+            m.is_confidential,
+            m.created_at,
+            m.updated_at,
+            u.name as author_name,
+            coalesce(up.display_name, u.name) as author_display_name
+       from messages m
+       join users u on u.id = m.author_id
+  left join user_profiles up on up.user_id = u.id
+      where m.id = $1`,
+    [messageId],
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return mapMessageRow(rows[0]);
+}
+
+export async function createMessage(params: {
+  threadId: string;
+  authorId: string;
+  body: string;
+  visibility: MessageVisibility;
+  isConfidential: boolean;
+}): Promise<MessageRecord> {
+  const messageId = randomUUID();
+  await query(
+    `insert into messages (id, thread_id, author_id, body, visibility, is_confidential)
+     values ($1, $2, $3, $4, $5, $6)` ,
+    [messageId, params.threadId, params.authorId, params.body, params.visibility, params.isConfidential],
+  );
+
+  const message = await getMessageById(messageId);
+  if (!message) {
+    throw new AppError('Failed to create message', 500);
+  }
+  return message;
+}

--- a/src/modules/messages/routes.ts
+++ b/src/modules/messages/routes.ts
@@ -1,0 +1,122 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { AppError } from '../../shared/errors';
+import {
+  createThreadBodySchema,
+  createMessageBodySchema,
+  listThreadsQuerySchema,
+  threadIdParamSchema,
+} from './schemas';
+import { createThread, getThreadWithMessages, listThreads, postMessage, userCanViewConfidential } from './service';
+
+const READ_REQUIREMENTS = { permissions: ['activities:read'] } as const;
+const WRITE_REQUIREMENTS = { permissions: ['activities:create'] } as const;
+
+export const messageRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/messages/threads', {
+    preHandler: [app.authenticate, app.authorize(READ_REQUIREMENTS)],
+  }, async (request) => {
+    const parsed = listThreadsQuerySchema.safeParse(request.query);
+
+    if (!parsed.success) {
+      throw new AppError('Consulta inválida', 400, parsed.error.flatten());
+    }
+
+    const threads = await listThreads({
+      userId: request.user.sub,
+      scope: parsed.data.scope,
+    });
+
+    return { data: threads };
+  });
+
+  app.post('/messages/threads', {
+    preHandler: [app.authenticate, app.authorize(WRITE_REQUIREMENTS)],
+  }, async (request, reply) => {
+    const parsed = createThreadBodySchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      throw new AppError('Dados inválidos', 400, parsed.error.flatten());
+    }
+
+    const uniqueMemberIds = Array.from(new Set(parsed.data.memberIds)).filter((id) => id !== request.user.sub);
+
+    const result = await createThread({
+      userId: request.user.sub,
+      scope: parsed.data.scope,
+      subject: parsed.data.subject ?? null,
+      visibility: parsed.data.visibility,
+      memberIds: uniqueMemberIds,
+      initialMessage: parsed.data.initialMessage,
+      roles: request.user.roles ?? [],
+      permissions: request.user.permissions ?? [],
+    });
+
+    return reply.code(201).send(result);
+  });
+
+  app.get('/messages/threads/:id', {
+    preHandler: [app.authenticate, app.authorize(READ_REQUIREMENTS)],
+  }, async (request) => {
+    const parsedParams = threadIdParamSchema.safeParse(request.params);
+
+    if (!parsedParams.success) {
+      throw new AppError('Parâmetros inválidos', 400, parsedParams.error.flatten());
+    }
+
+    const canViewConfidential = userCanViewConfidential(request.user.roles ?? [], request.user.permissions ?? []);
+
+    const result = await getThreadWithMessages({
+      threadId: parsedParams.data.id,
+      userId: request.user.sub,
+      canViewConfidential,
+    });
+
+    return result;
+  });
+
+  app.get('/messages/threads/:id/messages', {
+    preHandler: [app.authenticate, app.authorize(READ_REQUIREMENTS)],
+  }, async (request) => {
+    const parsedParams = threadIdParamSchema.safeParse(request.params);
+
+    if (!parsedParams.success) {
+      throw new AppError('Parâmetros inválidos', 400, parsedParams.error.flatten());
+    }
+
+    const canViewConfidential = userCanViewConfidential(request.user.roles ?? [], request.user.permissions ?? []);
+
+    const { messages } = await getThreadWithMessages({
+      threadId: parsedParams.data.id,
+      userId: request.user.sub,
+      canViewConfidential,
+    });
+
+    return { data: messages };
+  });
+
+  app.post('/messages/threads/:id/messages', {
+    preHandler: [app.authenticate, app.authorize(WRITE_REQUIREMENTS)],
+  }, async (request, reply) => {
+    const parsedParams = threadIdParamSchema.safeParse(request.params);
+    const parsedBody = createMessageBodySchema.safeParse(request.body);
+
+    if (!parsedParams.success || !parsedBody.success) {
+      throw new AppError('Requisição inválida', 400, {
+        params: parsedParams.success ? undefined : parsedParams.error.flatten(),
+        body: parsedBody.success ? undefined : parsedBody.error.flatten(),
+      });
+    }
+
+    const message = await postMessage({
+      threadId: parsedParams.data.id,
+      authorId: request.user.sub,
+      body: parsedBody.data.body,
+      visibility: parsedBody.data.visibility,
+      isConfidential: parsedBody.data.isConfidential,
+      roles: request.user.roles ?? [],
+      permissions: request.user.permissions ?? [],
+    });
+
+    return reply.code(201).send({ message });
+  });
+};

--- a/src/modules/messages/schemas.ts
+++ b/src/modules/messages/schemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const threadVisibilitySchema = z.enum(['internal', 'project', 'private']);
+export const messageVisibilitySchema = z.enum(['internal', 'project', 'private']);
+
+export const threadIdParamSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const listThreadsQuerySchema = z.object({
+  scope: z.string().trim().min(1).max(120).optional(),
+});
+
+export const createThreadBodySchema = z.object({
+  scope: z.string().trim().min(1).max(120),
+  subject: z.string().trim().min(1).max(200).nullable().optional(),
+  visibility: threadVisibilitySchema.optional(),
+  memberIds: z.array(z.string().uuid()).max(50).optional().default([]),
+  initialMessage: z
+    .object({
+      body: z.string().trim().min(1).max(5000),
+      visibility: messageVisibilitySchema.optional(),
+      isConfidential: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export const createMessageBodySchema = z.object({
+  body: z.string().trim().min(1).max(5000),
+  visibility: messageVisibilitySchema.optional(),
+  isConfidential: z.boolean().optional(),
+});

--- a/src/modules/messages/service.ts
+++ b/src/modules/messages/service.ts
@@ -1,0 +1,151 @@
+import { AppError, ForbiddenError, NotFoundError } from '../../shared/errors';
+import {
+  createMessage as insertMessage,
+  createThread as insertThread,
+  ensureUsersExist,
+  getThreadById,
+  isThreadMember,
+  listMessages as fetchMessages,
+  listThreadsForUser as fetchThreads,
+  type MessageRecord,
+  type MessageVisibility,
+  type ThreadRecord,
+  type ThreadVisibility,
+} from './repository';
+
+const DEFAULT_THREAD_VISIBILITY: ThreadVisibility = 'internal';
+const DEFAULT_MESSAGE_VISIBILITY: MessageVisibility = 'internal';
+const CONFIDENTIAL_ROLES = new Set(['admin', 'coordenacao', 'tecnica']);
+
+function canHandleConfidential(params: { roles: string[]; permissions: string[] }): boolean {
+  if (params.permissions.includes('activities:moderate')) {
+    return true;
+  }
+
+  return params.roles.some((role) => CONFIDENTIAL_ROLES.has(role));
+}
+
+export async function listThreads(params: {
+  userId: string;
+  scope?: string;
+}): Promise<ThreadRecord[]> {
+  return fetchThreads(params.userId, params.scope);
+}
+
+export async function getThreadWithMessages(params: {
+  threadId: string;
+  userId: string;
+  canViewConfidential: boolean;
+}): Promise<{ thread: ThreadRecord; messages: MessageRecord[] }> {
+  const thread = await getThreadById(params.threadId);
+  if (!thread) {
+    throw new NotFoundError('Thread não encontrada');
+  }
+
+  const isMember = await isThreadMember(params.threadId, params.userId);
+  if (!isMember) {
+    throw new ForbiddenError('Você não participa desta conversa');
+  }
+
+  const messages = await fetchMessages(params.threadId);
+  const filtered = params.canViewConfidential
+    ? messages
+    : messages.filter((message) => !message.isConfidential || message.author.id === params.userId);
+
+  return { thread, messages: filtered };
+}
+
+export async function createThread(params: {
+  userId: string;
+  scope: string;
+  subject: string | null;
+  visibility?: ThreadVisibility;
+  memberIds: string[];
+  initialMessage?: {
+    body: string;
+    visibility?: MessageVisibility;
+    isConfidential?: boolean;
+  };
+  roles: string[];
+  permissions: string[];
+}): Promise<{ thread: ThreadRecord; messages: MessageRecord[] }> {
+  await ensureUsersExist([...params.memberIds, params.userId]);
+
+  const visibility = params.visibility ?? DEFAULT_THREAD_VISIBILITY;
+  const canConfidential = params.initialMessage
+    ? canHandleConfidential({ roles: params.roles, permissions: params.permissions })
+    : false;
+
+  if (params.initialMessage?.isConfidential && !canConfidential) {
+    throw new ForbiddenError('Você não pode criar mensagens confidenciais');
+  }
+
+  const threadId = await insertThread({
+    scope: params.scope,
+    subject: params.subject,
+    visibility,
+    createdBy: params.userId,
+    memberIds: params.memberIds.filter((id) => id !== params.userId),
+  });
+
+  let messages: MessageRecord[] = [];
+
+  if (params.initialMessage) {
+    const message = await insertMessage({
+      threadId,
+      authorId: params.userId,
+      body: params.initialMessage.body,
+      visibility: params.initialMessage.visibility ?? DEFAULT_MESSAGE_VISIBILITY,
+      isConfidential: Boolean(params.initialMessage.isConfidential),
+    });
+
+    messages = [message];
+  }
+
+  const thread = await getThreadById(threadId);
+  if (!thread) {
+    throw new AppError('Falha ao carregar thread recém-criada', 500);
+  }
+
+  return { thread, messages };
+}
+
+export async function postMessage(params: {
+  threadId: string;
+  authorId: string;
+  body: string;
+  visibility?: MessageVisibility;
+  isConfidential?: boolean;
+  roles: string[];
+  permissions: string[];
+}): Promise<MessageRecord> {
+  const thread = await getThreadById(params.threadId);
+  if (!thread) {
+    throw new NotFoundError('Thread não encontrada');
+  }
+
+  const isMember = await isThreadMember(params.threadId, params.authorId);
+  if (!isMember) {
+    throw new ForbiddenError('Você não participa desta conversa');
+  }
+
+  const canConfidential = canHandleConfidential({ roles: params.roles, permissions: params.permissions });
+  const isConfidential = Boolean(params.isConfidential);
+  if (isConfidential && !canConfidential) {
+    throw new ForbiddenError('Você não pode criar mensagens confidenciais');
+  }
+
+  const message = await insertMessage({
+    threadId: params.threadId,
+    authorId: params.authorId,
+    body: params.body,
+    visibility: params.visibility ?? thread.visibility ?? DEFAULT_MESSAGE_VISIBILITY,
+    isConfidential,
+  });
+
+  return message;
+}
+
+export function userCanViewConfidential(roles: string[], permissions: string[]): boolean {
+  return canHandleConfidential({ roles, permissions });
+}

--- a/src/modules/register-modules.ts
+++ b/src/modules/register-modules.ts
@@ -11,11 +11,13 @@ import { analyticsRoutes } from './analytics/routes';
 import { formRoutes } from './forms/routes';
 import { consentRoutes } from './consents/routes';
 import { attachmentRoutes } from './attachments/routes';
+import { notificationRoutes } from './notifications/routes';
 import { auditRoutes } from './audit/routes';
 import { evolutionRoutes } from './evolutions/routes';
 import { actionPlanRoutes } from './action-plans/routes';
 import { timelineRoutes } from './timeline/routes';
 import { feedRoutes } from './feed/routes';
+import { messageRoutes } from './messages/routes';
 
 
 export async function registerModules(app: FastifyInstance) {
@@ -28,10 +30,12 @@ export async function registerModules(app: FastifyInstance) {
   await app.register(enrollmentRoutes);
   await app.register(analyticsRoutes);
   await app.register(feedRoutes);
+  await app.register(messageRoutes);
   await app.register(beneficiaryRoutes);
   await app.register(formRoutes);
   await app.register(consentRoutes);
   await app.register(attachmentRoutes);
+  await app.register(notificationRoutes);
   await app.register(auditRoutes);
   await app.register(evolutionRoutes);
   await app.register(actionPlanRoutes);

--- a/tests/integration/messages.threads.test.ts
+++ b/tests/integration/messages.threads.test.ts
@@ -1,0 +1,267 @@
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hash } from 'bcryptjs';
+import type { FastifyInstance } from 'fastify';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 30000 });
+
+const { mem, adapter } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { newDb } = require('pg-mem');
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  const adapter = db.adapters.createPg();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { v4 } = require('uuid');
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    implementation: () => v4(),
+  });
+  db.public.registerFunction({
+    name: 'trim',
+    args: ['text'],
+    returns: 'text',
+    implementation: (value: string | null) => (value ?? '').trim(),
+  });
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret-imm-123456789012345678901234567890';
+  process.env.JWT_EXPIRES_IN = '1h';
+  process.env.DATABASE_URL = 'postgres://imm:test@localhost:5432/imm_test';
+  process.env.LOG_LEVEL = 'debug';
+  process.env.SEED_DEMO_DATA = 'false';
+  return { mem: db, adapter };
+});
+
+vi.mock('pg', () => ({
+  Pool: adapter.Pool,
+  Client: adapter.Client,
+}));
+
+import { pool } from '../../src/db/pool';
+import { seedDatabase } from '../../src/scripts/seed';
+import { createApp } from '../../src/app';
+
+let app: FastifyInstance;
+
+async function loadSchema() {
+  const files = [
+    path.join(__dirname, '../../artifacts/sql/0001_initial.sql'),
+    path.join(__dirname, '../../artifacts/sql/0002_rbac_and_profiles.sql'),
+  ];
+
+  for (const sqlPath of files) {
+    const schemaSql = fs.readFileSync(sqlPath, 'utf8');
+    const sanitized = schemaSql
+      .replace(/--.*$/gm, '')
+      .split(';')
+      .map((statement) => statement.trim())
+      .filter(Boolean)
+      .filter((statement) => {
+        const lower = statement.toLowerCase();
+        return !lower.startsWith('create extension') && !lower.startsWith('create index');
+      });
+
+    for (const statement of sanitized) {
+      mem.public.none(statement);
+    }
+  }
+}
+
+async function login(appInstance: FastifyInstance, email: string, password: string) {
+  const response = await appInstance.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { email, password },
+  });
+
+  expect(response.statusCode).toBe(200);
+  return response.json().token as string;
+}
+
+async function createUserWithRole(params: { email: string; name: string; role: string }) {
+  const password = 'Test123!';
+  const passwordHash = await hash(password, 12);
+  const userId = randomUUID();
+  await pool.query(
+    `insert into users (id, name, email, password_hash) values ($1, $2, $3, $4)`,
+    [userId, params.name, params.email, passwordHash],
+  );
+
+  await pool.query(
+    `insert into user_profiles (user_id, display_name) values ($1, $2)`,
+    [userId, params.name],
+  );
+
+  const { rows } = await pool.query<{ id: number }>(
+    `select id from roles where slug = $1`,
+    [params.role],
+  );
+
+  const roleId = rows[0]?.id;
+  expect(roleId).toBeDefined();
+
+  await pool.query(
+    `insert into user_roles (id, user_id, role_id) values ($1, $2, $3)` ,
+    [randomUUID(), userId, roleId],
+  );
+
+  return { userId, password };
+}
+
+beforeAll(async () => {
+  await loadSchema();
+  await seedDatabase();
+  app = await createApp();
+  await app.ready();
+});
+
+afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
+  await pool.end();
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Messages module integration', () => {
+  it('allows authorized users to create threads with initial messages', async () => {
+    const tecnica = await createUserWithRole({ email: 'tecnica@imm.local', name: 'Técnica', role: 'tecnica' });
+    const educadora = await createUserWithRole({ email: 'educadora@imm.local', name: 'Educadora', role: 'educadora' });
+
+    const token = await login(app, 'tecnica@imm.local', tecnica.password);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/messages/threads',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        scope: 'beneficiary:123',
+        subject: 'Acompanhamento familiar',
+        memberIds: [educadora.userId],
+        initialMessage: {
+          body: 'Primeira mensagem confidencial',
+          isConfidential: false,
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = response.json();
+    expect(body.thread).toBeDefined();
+    expect(body.thread.members).toHaveLength(2);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].body).toBe('Primeira mensagem confidencial');
+  });
+
+  it('allows members to post messages in an existing thread', async () => {
+    const tecnica = await createUserWithRole({ email: 'tecnica2@imm.local', name: 'Técnica 2', role: 'tecnica' });
+    const educadora = await createUserWithRole({ email: 'educadora2@imm.local', name: 'Educadora 2', role: 'educadora' });
+
+    const tecnicaToken = await login(app, 'tecnica2@imm.local', tecnica.password);
+
+    const threadResponse = await app.inject({
+      method: 'POST',
+      url: '/messages/threads',
+      headers: { Authorization: `Bearer ${tecnicaToken}` },
+      payload: {
+        scope: 'project:alpha',
+        subject: 'Caso João',
+        memberIds: [educadora.userId],
+        initialMessage: {
+          body: 'Abrindo discussão do caso',
+        },
+      },
+    });
+
+    expect(threadResponse.statusCode).toBe(201);
+    const threadId = threadResponse.json().thread.id as string;
+
+    const educadoraToken = await login(app, 'educadora2@imm.local', educadora.password);
+
+    const postResponse = await app.inject({
+      method: 'POST',
+      url: `/messages/threads/${threadId}/messages`,
+      headers: { Authorization: `Bearer ${educadoraToken}` },
+      payload: {
+        body: 'Atualização realizada com a família',
+      },
+    });
+
+    expect(postResponse.statusCode).toBe(201);
+
+    const listResponse = await app.inject({
+      method: 'GET',
+      url: `/messages/threads/${threadId}/messages`,
+      headers: { Authorization: `Bearer ${educadoraToken}` },
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    const messages = listResponse.json().data as any[];
+    expect(messages).toHaveLength(2);
+    expect(messages[1].body).toBe('Atualização realizada com a família');
+  });
+
+  it('hides confidential messages from roles without clearance', async () => {
+    const tecnica = await createUserWithRole({ email: 'tecnica3@imm.local', name: 'Técnica 3', role: 'tecnica' });
+    const educadora = await createUserWithRole({ email: 'educadora3@imm.local', name: 'Educadora 3', role: 'educadora' });
+
+    const tecnicaToken = await login(app, 'tecnica3@imm.local', tecnica.password);
+
+    const threadResponse = await app.inject({
+      method: 'POST',
+      url: '/messages/threads',
+      headers: { Authorization: `Bearer ${tecnicaToken}` },
+      payload: {
+        scope: 'beneficiary:456',
+        subject: 'Caso confidencial',
+        memberIds: [educadora.userId],
+        initialMessage: {
+          body: 'Registro inicial visível',
+        },
+      },
+    });
+
+    const threadId = threadResponse.json().thread.id as string;
+
+    const confidentialResponse = await app.inject({
+      method: 'POST',
+      url: `/messages/threads/${threadId}/messages`,
+      headers: { Authorization: `Bearer ${tecnicaToken}` },
+      payload: {
+        body: 'Detalhes sensíveis',
+        isConfidential: true,
+      },
+    });
+
+    expect(confidentialResponse.statusCode).toBe(201);
+
+    const educadoraToken = await login(app, 'educadora3@imm.local', educadora.password);
+
+    const educadoraView = await app.inject({
+      method: 'GET',
+      url: `/messages/threads/${threadId}/messages`,
+      headers: { Authorization: `Bearer ${educadoraToken}` },
+    });
+
+    expect(educadoraView.statusCode).toBe(200);
+    const educadoraMessages = educadoraView.json().data as any[];
+    expect(educadoraMessages).toHaveLength(1);
+    expect(educadoraMessages[0].body).toBe('Registro inicial visível');
+
+    const tecnicaView = await app.inject({
+      method: 'GET',
+      url: `/messages/threads/${threadId}/messages`,
+      headers: { Authorization: `Bearer ${tecnicaToken}` },
+    });
+
+    expect(tecnicaView.statusCode).toBe(200);
+    const tecnicaMessages = tecnicaView.json().data as any[];
+    expect(tecnicaMessages).toHaveLength(2);
+    expect(tecnicaMessages[1].body).toBe('Detalhes sensíveis');
+  });
+});


### PR DESCRIPTION
## Summary
- add messages repository, service, schemas and routes with confidentiality and authorization checks
- register the messages module alongside other fastify routes
- add integration coverage for thread creation, posting messages and confidentiality visibility

## Testing
- npx vitest run tests/integration/messages.threads.test.ts
- npx vitest run tests/integration/notifications.webhooks.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d330f2c954832490f273498b695453