### PR TITLE
Enforce attendance validations for enrollment status

### DIFF
--- a/src/modules/enrollments/schemas.ts
+++ b/src/modules/enrollments/schemas.ts
@@ -10,11 +10,32 @@ export const createEnrollmentBodySchema = z.object({
   agreementAcceptance: z.record(z.string(), z.any()).optional(),
 });
 
-export const updateEnrollmentBodySchema = z.object({
-  status: enrollmentStatusSchema.optional(),
-  terminatedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  terminationReason: z.string().optional().nullable(),
-});
+export const updateEnrollmentBodySchema = z
+  .object({
+    status: enrollmentStatusSchema.optional(),
+    terminatedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    terminationReason: z.string().optional().nullable(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.status === 'terminated') {
+      const reason = data.terminationReason?.trim();
+      if (!reason) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['terminationReason'],
+          message: 'terminationReason is required when status is terminated',
+        });
+      }
+
+      if (data.terminatedAt === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['terminatedAt'],
+          message: 'terminatedAt is required when status is terminated',
+        });
+      }
+    }
+  });
 
 export const enrollmentIdParamSchema = z.object({
   id: z.string().uuid(),


### PR DESCRIPTION
## Summary
- block attendance recordings when enrollments are not active and reuse the refreshed enrollment data for notifications
- require termination details when terminating enrollments via request validation and repository safeguards
- extend enrollment service unit tests to cover suspended/terminated scenarios alongside existing risk flow checks

## Testing
- npx vitest run tests/enrollments.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d33fbab2a48324af6e95a47533932b