### PR TITLE
Add post reactions to feed

### DIFF
--- a/artifacts/sql/0004_feed_reactions.sql
+++ b/artifacts/sql/0004_feed_reactions.sql
@@ -1,0 +1,12 @@
+-- Feed post reactions
+create table if not exists post_reactions (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid not null references posts(id) on delete cascade,
+  author_id uuid not null references users(id),
+  type text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint uq_post_reactions_post_author unique (post_id, author_id)
+);
+
+create index if not exists idx_post_reactions_post on post_reactions (post_id);

--- a/src/modules/feed/schemas.ts
+++ b/src/modules/feed/schemas.ts
@@ -45,3 +45,12 @@ export const commentIdParamSchema = z.object({
 export const createCommentBodySchema = z.object({
   body: z.string().trim().min(1).max(2000),
 });
+
+export const createReactionBodySchema = z.object({
+  type: z.string().trim().min(1).max(32),
+});
+
+export const postReactionParamsSchema = z.object({
+  id: z.string().uuid(),
+  reactionId: z.string().uuid(),
+});


### PR DESCRIPTION
## Summary
- add the post_reactions table with uniqueness per post/author
- expose repository/service helpers to create, list and remove reactions with audit logging
- expose REST endpoints and tests for reacting to feed posts

## Testing
- `npm test` *(hangs on analytics.* tests, aborted after ~100s)*

------
https://chatgpt.com/codex/tasks/task_e_68d33fbabbfc8324a4daac4a002eb375