### PR TITLE
feat: notify action items near or past due

### DIFF
--- a/src/modules/notifications/service.ts
+++ b/src/modules/notifications/service.ts
@@ -243,6 +243,40 @@ function buildEmailMessage(event: NotificationEventWithTimestamp): { subject: st
           event.data.revokedAt ? `Revogado em: ${event.data.revokedAt}` : null,
         ].filter(Boolean).join('\n'),
       };
+    case 'action_item.due_soon': {
+      const beneficiary = event.data.beneficiaryName ?? event.data.beneficiaryId;
+      const dueText = event.data.dueInDays <= 0
+        ? 'vence hoje'
+        : `vence em ${event.data.dueInDays} dia(s)`;
+      return {
+        subject: `Ação próxima do prazo - ${event.data.title}`,
+        body: [
+          `Ação "${event.data.title}" ${dueText}.`,
+          `Beneficiário(a): ${beneficiary}`,
+          `Plano de ação: ${event.data.actionPlanId}`,
+          `Data limite: ${event.data.dueDate}`,
+          event.data.responsible ? `Responsável: ${event.data.responsible}` : null,
+          `Status atual: ${event.data.status}`,
+        ].filter(Boolean).join('\n'),
+      };
+    }
+    case 'action_item.overdue': {
+      const beneficiary = event.data.beneficiaryName ?? event.data.beneficiaryId;
+      const overdueText = event.data.overdueByDays <= 1
+        ? '1 dia'
+        : `${event.data.overdueByDays} dias`;
+      return {
+        subject: `Ação em atraso - ${event.data.title}`,
+        body: [
+          `Ação "${event.data.title}" atrasada há ${overdueText}.`,
+          `Beneficiário(a): ${beneficiary}`,
+          `Plano de ação: ${event.data.actionPlanId}`,
+          `Data limite: ${event.data.dueDate}`,
+          event.data.responsible ? `Responsável: ${event.data.responsible}` : null,
+          `Status atual: ${event.data.status}`,
+        ].filter(Boolean).join('\n'),
+      };
+    }
     default:
       return null;
   }
@@ -263,6 +297,20 @@ function buildWhatsAppMessage(event: NotificationEventWithTimestamp): string | n
       return `Consentimento ${event.data.type} registrado para beneficiário ${event.data.beneficiaryId}.`;
     case 'consent.updated':
       return `Consentimento ${event.data.type} atualizado (${event.data.granted ? 'ativo' : 'revogado'}).`;
+    case 'action_item.due_soon': {
+      const beneficiary = event.data.beneficiaryName ?? event.data.beneficiaryId;
+      const dueText = event.data.dueInDays <= 0
+        ? 'vence hoje'
+        : `vence em ${event.data.dueInDays} dia(s)`;
+      return `Lembrete: ação "${event.data.title}" ${dueText} (beneficiário ${beneficiary}).`;
+    }
+    case 'action_item.overdue': {
+      const beneficiary = event.data.beneficiaryName ?? event.data.beneficiaryId;
+      const overdueText = event.data.overdueByDays <= 1
+        ? '1 dia'
+        : `${event.data.overdueByDays} dias`;
+      return `Alerta: ação "${event.data.title}" atrasada há ${overdueText} (beneficiário ${beneficiary}).`;
+    }
     default:
       return null;
   }

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -72,12 +72,46 @@ export type ConsentUpdatedEvent = {
   };
 };
 
+export type ActionItemDueSoonEvent = {
+  type: 'action_item.due_soon';
+  triggeredAt?: string;
+  data: {
+    actionPlanId: string;
+    actionItemId: string;
+    beneficiaryId: string;
+    beneficiaryName: string | null;
+    title: string;
+    dueDate: string;
+    responsible: string | null;
+    status: string;
+    dueInDays: number;
+  };
+};
+
+export type ActionItemOverdueEvent = {
+  type: 'action_item.overdue';
+  triggeredAt?: string;
+  data: {
+    actionPlanId: string;
+    actionItemId: string;
+    beneficiaryId: string;
+    beneficiaryName: string | null;
+    title: string;
+    dueDate: string;
+    responsible: string | null;
+    status: string;
+    overdueByDays: number;
+  };
+};
+
 export type NotificationEvent =
   | EnrollmentCreatedEvent
   | AttendanceRecordedEvent
   | AttendanceLowAttendanceEvent
   | ConsentRecordedEvent
-  | ConsentUpdatedEvent;
+  | ConsentUpdatedEvent
+  | ActionItemDueSoonEvent
+  | ActionItemOverdueEvent;
 
 export type NotificationChannel = 'email' | 'whatsapp' | 'webhook';
 

--- a/tests/action-plans.service.test.ts
+++ b/tests/action-plans.service.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActionItemRecord, ActionPlanRecord } from '../src/modules/action-plans/repository';
+import { addActionItem, runActionItemReminderScan, updateActionItem } from '../src/modules/action-plans/service';
+
+const {
+  createActionItemMock,
+  updateActionItemMock,
+  getActionItemByIdMock,
+  listActionItemsDueBeforeMock,
+  getBeneficiaryNameByIdMock,
+} = vi.hoisted(() => ({
+  createActionItemMock: vi.fn(),
+  updateActionItemMock: vi.fn(),
+  getActionItemByIdMock: vi.fn(),
+  listActionItemsDueBeforeMock: vi.fn(),
+  getBeneficiaryNameByIdMock: vi.fn(),
+}));
+
+const { recordAuditLogMock } = vi.hoisted(() => ({
+  recordAuditLogMock: vi.fn(),
+}));
+
+const { publishNotificationEventMock } = vi.hoisted(() => ({
+  publishNotificationEventMock: vi.fn(),
+}));
+
+vi.mock('../src/modules/action-plans/repository', () => ({
+  createActionItem: createActionItemMock,
+  updateActionItem: updateActionItemMock,
+  getActionItemById: getActionItemByIdMock,
+  getActionPlan: vi.fn(),
+  listActionItemsForBeneficiary: vi.fn(),
+  listActionPlans: vi.fn(),
+  createActionPlan: vi.fn(),
+  updateActionPlan: vi.fn(),
+  listActionItemsDueBefore: listActionItemsDueBeforeMock,
+  getBeneficiaryNameById: getBeneficiaryNameByIdMock,
+}));
+
+vi.mock('../src/shared/audit', () => ({
+  recordAuditLog: recordAuditLogMock,
+}));
+
+vi.mock('../src/modules/notifications/service', () => ({
+  publishNotificationEvent: publishNotificationEventMock,
+}));
+
+describe('action plan service notifications', () => {
+  const basePlan: ActionPlanRecord = {
+    id: 'plan-1',
+    beneficiaryId: 'ben-1',
+    status: 'active',
+    createdBy: 'user-1',
+    createdAt: '2024-06-01T00:00:00.000Z',
+    updatedAt: '2024-06-01T00:00:00.000Z',
+    items: [],
+  };
+
+  const createItem = (overrides?: Partial<ActionItemRecord>): ActionItemRecord => ({
+    id: overrides?.id ?? 'item-1',
+    actionPlanId: overrides?.actionPlanId ?? 'plan-1',
+    title: overrides?.title ?? 'Preparar documentação',
+    responsible: overrides?.responsible ?? 'Equipe Social',
+    dueDate: overrides?.dueDate ?? '2024-06-11',
+    status: overrides?.status ?? 'pending',
+    support: overrides?.support ?? null,
+    notes: overrides?.notes ?? null,
+    completedAt: overrides?.completedAt ?? null,
+    createdAt: overrides?.createdAt ?? '2024-06-01T00:00:00.000Z',
+    updatedAt: overrides?.updatedAt ?? '2024-06-01T00:00:00.000Z',
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-10T12:00:00.000Z'));
+    vi.clearAllMocks();
+    recordAuditLogMock.mockResolvedValue(undefined);
+    getBeneficiaryNameByIdMock.mockResolvedValue('Fulana de Tal');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('publica evento de item próximo do prazo ao criar ação', async () => {
+    const planWithItem: ActionPlanRecord = {
+      ...basePlan,
+      items: [createItem({ id: 'item-new', dueDate: '2024-06-11' })],
+    };
+    createActionItemMock.mockResolvedValue(planWithItem);
+
+    await addActionItem({
+      actionPlanId: basePlan.id,
+      title: 'Preparar documentação',
+      dueDate: '2024-06-11',
+    });
+
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'action_item.due_soon',
+        data: expect.objectContaining({
+          actionItemId: 'item-new',
+          beneficiaryName: 'Fulana de Tal',
+          dueInDays: 1,
+        }),
+      }),
+    );
+  });
+
+  it('publica evento de atraso ao atualizar ação vencida', async () => {
+    const existingItem = createItem({ id: 'item-2', dueDate: '2024-06-05' });
+    getActionItemByIdMock.mockResolvedValue(existingItem);
+
+    const updatedPlan: ActionPlanRecord = {
+      ...basePlan,
+      items: [existingItem],
+    };
+    updateActionItemMock.mockResolvedValue(updatedPlan);
+
+    await updateActionItem({
+      actionPlanId: basePlan.id,
+      itemId: 'item-2',
+      dueDate: '2024-06-05',
+    });
+
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'action_item.overdue',
+        data: expect.objectContaining({
+          actionItemId: 'item-2',
+          overdueByDays: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  it('varre itens pendentes e publica eventos conforme prazo', async () => {
+    const dueSoon = createItem({ id: 'item-3', dueDate: '2024-06-12' });
+    const overdue = createItem({ id: 'item-4', dueDate: '2024-06-08' });
+
+    listActionItemsDueBeforeMock.mockResolvedValue([
+      { ...dueSoon, beneficiaryId: 'ben-1', beneficiaryName: 'Fulana de Tal' },
+      { ...overdue, beneficiaryId: 'ben-2', beneficiaryName: null },
+    ]);
+
+    await runActionItemReminderScan(new Date('2024-06-10T12:00:00.000Z'));
+
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'action_item.due_soon' }),
+    );
+    expect(publishNotificationEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'action_item.overdue' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add action item due soon and overdue event types and notification templates
- emit reminders when action items approach or pass their due dates and introduce a scheduled scan helper
- expand tests to cover the new action item notification flows

## Testing
- `npm test` *(hangs on analytics suites; aborted after ~8 minutes)*
- `npx vitest run tests/notifications.service.test.ts tests/action-plans.service.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d33fbab7a883248a26140d96adf097