### PR TITLE
Implement password reset workflow with notifications

### DIFF
--- a/artifacts/sql/0005_password_reset_tokens.sql
+++ b/artifacts/sql/0005_password_reset_tokens.sql
@@ -1,0 +1,11 @@
+create table if not exists password_reset_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  token_hash text not null unique,
+  expires_at timestamptz not null,
+  used_at timestamptz,
+  created_at timestamptz default now()
+);
+
+create index if not exists password_reset_tokens_user_idx on password_reset_tokens(user_id);
+create index if not exists password_reset_tokens_expires_idx on password_reset_tokens(expires_at);

--- a/src/modules/auth/repository.ts
+++ b/src/modules/auth/repository.ts
@@ -1,0 +1,115 @@
+import type { PoolClient } from 'pg';
+import { query } from '../../db';
+
+export type PasswordResetTokenRecord = {
+  id: string;
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+  usedAt: Date | null;
+  createdAt: Date;
+};
+
+function mapRow(row: {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  expires_at: Date;
+  used_at: Date | null;
+  created_at: Date;
+}): PasswordResetTokenRecord {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    tokenHash: row.token_hash,
+    expiresAt: row.expires_at,
+    usedAt: row.used_at,
+    createdAt: row.created_at,
+  };
+}
+
+async function execute<T>(
+  sql: string,
+  values: unknown[],
+  client?: PoolClient,
+): Promise<T[]> {
+  if (client) {
+    const result = await client.query<T>(sql, values);
+    return result.rows;
+  }
+
+  const result = await query<T>(sql, values);
+  return result.rows;
+}
+
+export async function deletePasswordResetTokensForUser(
+  userId: string,
+  client?: PoolClient,
+): Promise<void> {
+  await execute('delete from password_reset_tokens where user_id = $1', [userId], client);
+}
+
+export async function deleteExpiredPasswordResetTokens(client?: PoolClient): Promise<void> {
+  await execute('delete from password_reset_tokens where expires_at < now()', [], client);
+}
+
+export async function insertPasswordResetToken(
+  params: { userId: string; tokenHash: string; expiresAt: Date },
+  client?: PoolClient,
+): Promise<PasswordResetTokenRecord> {
+  const rows = await execute<{
+    id: string;
+    user_id: string;
+    token_hash: string;
+    expires_at: Date;
+    used_at: Date | null;
+    created_at: Date;
+  }>(
+    `insert into password_reset_tokens (user_id, token_hash, expires_at)
+     values ($1, $2, $3)
+     returning id, user_id, token_hash, expires_at, used_at, created_at`,
+    [params.userId, params.tokenHash, params.expiresAt],
+    client,
+  );
+
+  return mapRow(rows[0]!);
+}
+
+export async function findPasswordResetTokenByHash(
+  tokenHash: string,
+  client?: PoolClient,
+): Promise<PasswordResetTokenRecord | null> {
+  const rows = await execute<{
+    id: string;
+    user_id: string;
+    token_hash: string;
+    expires_at: Date;
+    used_at: Date | null;
+    created_at: Date;
+  }>(
+    `select id, user_id, token_hash, expires_at, used_at, created_at
+       from password_reset_tokens
+      where token_hash = $1`,
+    [tokenHash],
+    client,
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return mapRow(rows[0]!);
+}
+
+export async function markPasswordResetTokenUsed(
+  tokenId: string,
+  client?: PoolClient,
+): Promise<void> {
+  await execute(
+    `update password_reset_tokens
+        set used_at = now()
+      where id = $1`,
+    [tokenId],
+    client,
+  );
+}

--- a/src/modules/auth/schemas.ts
+++ b/src/modules/auth/schemas.ts
@@ -6,3 +6,13 @@ export const loginBodySchema = z.object({
 });
 
 export type LoginBody = z.infer<typeof loginBodySchema>;
+
+export const passwordForgotBodySchema = z.object({
+  email: z.string().email(),
+  redirectTo: z.string().url().optional(),
+});
+
+export const passwordResetBodySchema = z.object({
+  token: z.string().min(10),
+  password: z.string().min(8),
+});

--- a/src/modules/auth/service.ts
+++ b/src/modules/auth/service.ts
@@ -1,6 +1,17 @@
 import { compare } from 'bcryptjs';
-import { UnauthorizedError } from '../../shared/errors';
+import { createHash, randomBytes } from 'crypto';
+import { withTransaction } from '../../db';
+import { AppError, UnauthorizedError } from '../../shared/errors';
+import { publishNotificationEvent } from '../notifications/service';
 import { getUserByEmailWithPassword, type PermissionGrant } from '../users/repository';
+import { hashPassword } from '../users/service';
+import {
+  deleteExpiredPasswordResetTokens,
+  deletePasswordResetTokensForUser,
+  findPasswordResetTokenByHash,
+  insertPasswordResetToken,
+  markPasswordResetTokenUsed,
+} from './repository';
 
 export type AuthenticatedUser = {
   id: string;
@@ -9,6 +20,10 @@ export type AuthenticatedUser = {
   roles: { slug: string; projectId?: string | null }[];
   permissions: PermissionGrant[];
 };
+
+const RESET_TOKEN_BYTE_LENGTH = 32;
+const RESET_TOKEN_EXPIRATION_MINUTES = 60;
+const DEFAULT_RESET_URL = 'https://imm.local/reset-password';
 
 export async function validateCredentials(email: string, password: string): Promise<AuthenticatedUser> {
   const user = await getUserByEmailWithPassword(email);
@@ -30,4 +45,89 @@ export async function validateCredentials(email: string, password: string): Prom
     roles: user.roles,
     permissions: user.permissions,
   };
+}
+
+function generateResetToken(): string {
+  return randomBytes(RESET_TOKEN_BYTE_LENGTH).toString('hex');
+}
+
+function hashResetToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function resolveResetUrl(token: string, redirectTo?: string): string {
+  const baseUrl = redirectTo && redirectTo.trim().length > 0 ? redirectTo : DEFAULT_RESET_URL;
+
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new AppError('Invalid redirect URL', 400);
+  }
+
+  url.searchParams.set('token', token);
+  return url.toString();
+}
+
+export async function requestPasswordReset(email: string, redirectTo?: string): Promise<void> {
+  const user = await getUserByEmailWithPassword(email);
+
+  if (!user || !user.isActive) {
+    return;
+  }
+
+  const token = generateResetToken();
+  const tokenHash = hashResetToken(token);
+  const expiresAt = new Date(Date.now() + RESET_TOKEN_EXPIRATION_MINUTES * 60 * 1000);
+
+  await withTransaction(async (client) => {
+    await deleteExpiredPasswordResetTokens(client);
+    await deletePasswordResetTokensForUser(user.id, client);
+    await insertPasswordResetToken({
+      userId: user.id,
+      tokenHash,
+      expiresAt,
+    }, client);
+  });
+
+  const resetUrl = resolveResetUrl(token, redirectTo);
+
+  publishNotificationEvent({
+    type: 'auth.password_reset_requested',
+    data: {
+      email: user.email,
+      name: user.name,
+      resetUrl,
+      expiresAt: expiresAt.toISOString(),
+    },
+  });
+}
+
+export async function resetPasswordWithToken(token: string, newPassword: string): Promise<void> {
+  const tokenHash = hashResetToken(token);
+  const record = await findPasswordResetTokenByHash(tokenHash);
+
+  if (!record || record.usedAt || record.expiresAt.getTime() <= Date.now()) {
+    throw new AppError('Invalid or expired reset token', 400);
+  }
+
+  const passwordHash = await hashPassword(newPassword);
+
+  await withTransaction(async (client) => {
+    await client.query(
+      `update users
+          set password_hash = $1,
+              updated_at = now()
+        where id = $2`,
+      [passwordHash, record.userId],
+    );
+
+    await markPasswordResetTokenUsed(record.id, client);
+    await client.query(
+      `delete from password_reset_tokens
+        where user_id = $1
+          and id <> $2`,
+      [record.userId, record.id],
+    );
+  });
 }

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -104,6 +104,17 @@ export type ActionItemOverdueEvent = {
   };
 };
 
+export type PasswordResetRequestedEvent = {
+  type: 'auth.password_reset_requested';
+  triggeredAt?: string;
+  data: {
+    email: string;
+    name: string;
+    resetUrl: string;
+    expiresAt: string;
+  };
+};
+
 export type NotificationEvent =
   | EnrollmentCreatedEvent
   | AttendanceRecordedEvent
@@ -111,7 +122,8 @@ export type NotificationEvent =
   | ConsentRecordedEvent
   | ConsentUpdatedEvent
   | ActionItemDueSoonEvent
-  | ActionItemOverdueEvent;
+  | ActionItemOverdueEvent
+  | PasswordResetRequestedEvent;
 
 export type NotificationChannel = 'email' | 'whatsapp' | 'webhook';
 

--- a/src/modules/users/service.ts
+++ b/src/modules/users/service.ts
@@ -5,6 +5,10 @@ import { createUser as createUserRepository, getUserByEmailWithPassword, listUse
 
 const SALT_ROUNDS = 12;
 
+export async function hashPassword(plainPassword: string): Promise<string> {
+  return hash(plainPassword, SALT_ROUNDS);
+}
+
 export type CreateUserInput = {
   name: string;
   email: string;
@@ -19,7 +23,7 @@ export async function createUser(input: CreateUserInput): Promise<UserRecord> {
     throw new AppError('Email already in use', 409);
   }
 
-  const passwordHash = await hash(input.password, SALT_ROUNDS);
+  const passwordHash = await hashPassword(input.password);
   const roles = input.roles.map((role) => ({ slug: role.slug, projectId: role.projectId ?? null }));
 
   return createUserRepository({

--- a/tests/integration/auth.password-reset.test.ts
+++ b/tests/integration/auth.password-reset.test.ts
@@ -1,0 +1,237 @@
+import fs from 'fs';
+import path from 'path';
+import { createHash, randomUUID, randomBytes } from 'crypto';
+import { compare } from 'bcryptjs';
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 30000 });
+
+const { mem, adapter } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { newDb } = require('pg-mem');
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  const adapter = db.adapters.createPg();
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    implementation: () => randomUUID(),
+  });
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret-imm-123456789012345678901234567890';
+  process.env.JWT_EXPIRES_IN = '1h';
+  process.env.DATABASE_URL = 'postgres://imm:test@localhost:5432/imm_test';
+  process.env.LOG_LEVEL = 'debug';
+  process.env.NOTIFICATIONS_EMAIL_RECIPIENTS = '';
+  process.env.NOTIFICATIONS_WHATSAPP_NUMBERS = '';
+  process.env.NOTIFICATIONS_WEBHOOK_TIMEOUT_MS = '100';
+  return { mem: db, adapter };
+});
+
+vi.mock('pg', () => ({
+  Pool: adapter.Pool,
+  Client: adapter.Client,
+}));
+
+import { pool } from '../../src/db/pool';
+import { seedDatabase } from '../../src/scripts/seed';
+import { createApp } from '../../src/app';
+import {
+  getEmailDispatchHistory,
+  resetNotificationDispatchHistory,
+  waitForNotificationQueue,
+} from '../../src/modules/notifications/service';
+import { hashPassword } from '../../src/modules/users/service';
+
+let app: FastifyInstance;
+
+async function loadSchema() {
+  const files = [
+    path.join(__dirname, '../../artifacts/sql/0001_initial.sql'),
+    path.join(__dirname, '../../artifacts/sql/0002_rbac_and_profiles.sql'),
+    path.join(__dirname, '../../artifacts/sql/0005_password_reset_tokens.sql'),
+  ];
+
+  for (const sqlPath of files) {
+    const schemaSql = fs.readFileSync(sqlPath, 'utf8');
+    const sanitized = schemaSql
+      .replace(/--.*$/gm, '')
+      .split(';')
+      .map((statement) => statement.trim())
+      .filter(Boolean)
+      .filter((statement) => {
+        const lower = statement.toLowerCase();
+        return !lower.startsWith('create extension') && !lower.startsWith('create index');
+      });
+
+    for (const statement of sanitized) {
+      mem.public.none(statement);
+    }
+  }
+}
+
+async function createTestUser(params: { email: string; password: string; name?: string }) {
+  const userId = randomUUID();
+  const passwordHash = await hashPassword(params.password);
+  await pool.query(
+    `insert into users (id, name, email, password_hash)
+     values ($1, $2, $3, $4)`,
+    [userId, params.name ?? 'Test User', params.email, passwordHash],
+  );
+
+  return { id: userId };
+}
+
+beforeAll(async () => {
+  await loadSchema();
+  await seedDatabase();
+  app = await createApp();
+  await app.ready();
+});
+
+afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
+  await pool.end();
+});
+
+beforeEach(async () => {
+  resetNotificationDispatchHistory();
+  await pool.query('delete from password_reset_tokens');
+});
+
+describe('Password reset flows', () => {
+  it('creates reset token and dispatches notification for existing user', async () => {
+    const email = `user-${Date.now()}@example.com`;
+    const user = await createTestUser({ email, password: 'Initial123!' });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/password/forgot',
+      payload: {
+        email,
+        redirectTo: 'https://frontend.example/reset?lang=pt',
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+
+    await waitForNotificationQueue();
+
+    const tokens = await pool.query<{ token_hash: string; expires_at: Date }>(
+      'select token_hash, expires_at from password_reset_tokens where user_id = $1',
+      [user.id],
+    );
+
+    expect(tokens.rowCount).toBe(1);
+    expect(tokens.rows[0].expires_at).toBeInstanceOf(Date);
+
+    const emails = getEmailDispatchHistory();
+    expect(emails).toHaveLength(1);
+    const emailDispatch = emails[0];
+    expect(emailDispatch.recipients).toEqual([email]);
+    expect(emailDispatch.eventType).toBe('auth.password_reset_requested');
+    expect(emailDispatch.body).toContain('frontend.example/reset');
+    expect(emailDispatch.body).toContain('lang=pt');
+
+    const tokenMatch = emailDispatch.body.match(/token=([A-Za-z0-9]+)/);
+    expect(tokenMatch?.[1]).toBeDefined();
+    const rawToken = tokenMatch![1];
+    const hashed = createHash('sha256').update(rawToken).digest('hex');
+    expect(hashed).toBe(tokens.rows[0].token_hash);
+  });
+
+  it('resets password using a valid token and invalidates reuse', async () => {
+    const email = `user-${Date.now()}@imm.local`;
+    const user = await createTestUser({ email, password: 'OldPass123!' });
+
+    const forgot = await app.inject({
+      method: 'POST',
+      url: '/auth/password/forgot',
+      payload: { email },
+    });
+
+    expect(forgot.statusCode).toBe(202);
+    await waitForNotificationQueue();
+
+    const emails = getEmailDispatchHistory();
+    const body = emails[0]?.body ?? '';
+    const tokenMatch = body.match(/token=([A-Za-z0-9]+)/);
+    expect(tokenMatch?.[1]).toBeDefined();
+    const token = tokenMatch![1];
+
+    const reset = await app.inject({
+      method: 'POST',
+      url: '/auth/password/reset',
+      payload: {
+        token,
+        password: 'NewSecret456!',
+      },
+    });
+
+    expect(reset.statusCode).toBe(204);
+
+    const saved = await pool.query<{ password_hash: string }>(
+      'select password_hash from users where id = $1',
+      [user.id],
+    );
+    expect(saved.rowCount).toBe(1);
+    const matches = await compare('NewSecret456!', saved.rows[0].password_hash);
+    expect(matches).toBe(true);
+
+    const tokens = await pool.query<{ used_at: Date | null }>(
+      'select used_at from password_reset_tokens where user_id = $1',
+      [user.id],
+    );
+    expect(tokens.rowCount).toBeGreaterThan(0);
+    expect(tokens.rows[0].used_at).toBeInstanceOf(Date);
+
+    const reuse = await app.inject({
+      method: 'POST',
+      url: '/auth/password/reset',
+      payload: {
+        token,
+        password: 'AnotherPass789!',
+      },
+    });
+
+    expect(reuse.statusCode).toBe(400);
+    expect(reuse.json().message).toBe('Invalid or expired reset token');
+  });
+
+  it('rejects expired reset tokens', async () => {
+    const email = `expired-${Date.now()}@imm.local`;
+    const user = await createTestUser({ email, password: 'TempPass123!' });
+
+    const token = randomBytes(32).toString('hex');
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    const expiresAt = new Date(Date.now() - 5 * 60 * 1000);
+
+    await pool.query(
+      `insert into password_reset_tokens (id, user_id, token_hash, expires_at)
+       values ($1, $2, $3, $4)`,
+      [randomUUID(), user.id, tokenHash, expiresAt],
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/auth/password/reset',
+      payload: {
+        token,
+        password: 'NeverChanges123!',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().message).toBe('Invalid or expired reset token');
+
+    const saved = await pool.query<{ password_hash: string }>(
+      'select password_hash from users where id = $1',
+      [user.id],
+    );
+    expect(saved.rowCount).toBe(1);
+    const stillMatches = await compare('TempPass123!', saved.rows[0].password_hash);
+    expect(stillMatches).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a migration creating the `password_reset_tokens` table to track recovery attempts
- implement repository and service helpers plus `/auth/password/forgot` and `/auth/password/reset` endpoints that send notification emails
- extend the notification system with a password reset event and add integration tests covering token issuance, reuse prevention, and expiration

## Testing
- npm test *(interrupted after analytics suites stalled; earlier suites completed successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68d34a989cc4832480abd0246d1da320