### PR TITLE
Fix pg-mem scope filters for project-restricted queries

### DIFF
--- a/src/modules/auth/plugin.ts
+++ b/src/modules/auth/plugin.ts
@@ -38,6 +38,20 @@ export async function registerAuthDecorators(app: FastifyInstance) {
     if (!shouldAllow) {
       throw new ForbiddenError('Insufficient permissions');
     }
+
+    const requiredProjectPermissions = permissions.filter((permission) => permission.endsWith(':project'));
+    if (requiredProjectPermissions.length > 0) {
+      const userProjectPermissions = requiredProjectPermissions.filter((permission) => userPermissions.has(permission));
+      if (userProjectPermissions.length > 0) {
+        const projectScopes = Array.isArray(request.user?.projectScopes) ? request.user?.projectScopes ?? [] : [];
+        const hasGlobalRole = Array.isArray(request.user?.roles)
+          ? request.user.roles.some((role) => role === 'admin')
+          : false;
+        if (!hasGlobalRole && projectScopes.length === 0) {
+          throw new ForbiddenError('Project scope required');
+        }
+      }
+    }
   });
 }
 

--- a/src/modules/beneficiaries/routes.ts
+++ b/src/modules/beneficiaries/routes.ts
@@ -30,7 +30,14 @@ export const beneficiaryRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid query', 400, parsedQuery.error.flatten());
     }
 
-    const data = await listBeneficiarySummaries(parsedQuery.data);
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
+    const data = await listBeneficiarySummaries({
+      ...parsedQuery.data,
+      allowedProjectIds,
+    });
 
     return {
       data,
@@ -74,7 +81,11 @@ export const beneficiaryRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid params', 400, parsedParams.error.flatten());
     }
 
-    const record = await getBeneficiary(parsedParams.data.id);
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
+    const record = await getBeneficiary(parsedParams.data.id, allowedProjectIds);
     return { beneficiary: record };
   });
 
@@ -93,8 +104,12 @@ export const beneficiaryRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid body', 400, parsedBody.error.flatten());
     }
 
-    const before = await getBeneficiary(parsedParams.data.id);
-    const record = await updateBeneficiary(parsedParams.data.id, parsedBody.data);
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
+    const before = await getBeneficiary(parsedParams.data.id, allowedProjectIds);
+    const record = await updateBeneficiary(parsedParams.data.id, parsedBody.data, allowedProjectIds);
 
     await recordAuditLog({
       userId: request.user?.sub ?? null,

--- a/src/modules/beneficiaries/service.ts
+++ b/src/modules/beneficiaries/service.ts
@@ -12,12 +12,17 @@ export async function createBeneficiary(input: CreateBeneficiaryParams) {
   return createBeneficiaryRepository(input);
 }
 
-export async function updateBeneficiary(id: string, input: UpdateBeneficiaryParams) {
+export async function updateBeneficiary(
+  id: string,
+  input: UpdateBeneficiaryParams,
+  allowedProjectIds?: string[] | null,
+) {
+  await getBeneficiaryById(id, allowedProjectIds ?? null);
   return updateBeneficiaryRepository(id, input);
 }
 
-export async function getBeneficiary(id: string) {
-  const record = await getBeneficiaryById(id);
+export async function getBeneficiary(id: string, allowedProjectIds?: string[] | null) {
+  const record = await getBeneficiaryById(id, allowedProjectIds ?? null);
 
   if (!record) {
     throw new NotFoundError('Beneficiary not found');
@@ -26,7 +31,12 @@ export async function getBeneficiary(id: string) {
   return record;
 }
 
-export async function listBeneficiarySummaries(params: { search?: string; limit?: number; offset?: number }) {
+export async function listBeneficiarySummaries(params: {
+  search?: string;
+  limit?: number;
+  offset?: number;
+  allowedProjectIds?: string[] | null;
+}) {
   const limit = Math.min(params.limit ?? 25, 100);
   const offset = params.offset ?? 0;
 
@@ -38,5 +48,7 @@ export async function listBeneficiarySummaries(params: { search?: string; limit?
     throw new AppError('offset cannot be negative', 400);
   }
 
-  return listBeneficiaries({ search: params.search, limit, offset });
+  const scopes = params.allowedProjectIds && params.allowedProjectIds.length > 0 ? params.allowedProjectIds : null;
+
+  return listBeneficiaries({ search: params.search, limit, offset, allowedProjectIds: scopes });
 }

--- a/src/modules/certificates/routes.ts
+++ b/src/modules/certificates/routes.ts
@@ -50,11 +50,16 @@ export const certificateRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid body', 400, parsedBody.error.flatten());
     }
 
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
     const certificate = await issueCertificate({
       enrollmentId: parsedParams.data.id,
       issuedBy: request.user?.sub ?? null,
       type: parsedBody.data.type,
       metadata: parsedBody.data.metadata ?? null,
+      allowedProjectIds,
     });
 
     return reply.code(201).send({ certificate });
@@ -73,6 +78,10 @@ export const certificateRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid query', 400, parsedQuery.error.flatten());
     }
 
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
     const limit = parsedQuery.data.limit ?? 50;
     const offset = parsedQuery.data.offset ?? 0;
 
@@ -80,6 +89,7 @@ export const certificateRoutes: FastifyPluginAsync = async (app) => {
       enrollmentId: parsedParams.data.id,
       limit,
       offset,
+      allowedProjectIds,
     });
 
     return {
@@ -100,7 +110,12 @@ export const certificateRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid params', 400, parsedParams.error.flatten());
     }
 
-    const certificate = await getCertificateOrFail(parsedParams.data.id);
+    const certificate = await getCertificateOrFail(
+      parsedParams.data.id,
+      request.user.projectScopes && request.user.projectScopes.length > 0
+        ? request.user.projectScopes
+        : null,
+    );
     return { certificate };
   });
 
@@ -112,7 +127,12 @@ export const certificateRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid params', 400, parsedParams.error.flatten());
     }
 
-    const { metadata, buffer } = await loadCertificateFile(parsedParams.data.id);
+    const { metadata, buffer } = await loadCertificateFile(
+      parsedParams.data.id,
+      request.user.projectScopes && request.user.projectScopes.length > 0
+        ? request.user.projectScopes
+        : null,
+    );
 
     reply.header('Content-Type', metadata.mimeType);
     reply.header('Content-Disposition', `attachment; filename="${metadata.fileName}"`);

--- a/src/modules/enrollments/routes.ts
+++ b/src/modules/enrollments/routes.ts
@@ -33,9 +33,14 @@ export const enrollmentRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid body', 400, parsedBody.error.flatten());
     }
 
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
     const enrollment = await createEnrollment({
       ...parsedBody.data,
       agreementAcceptance: parsedBody.data.agreementAcceptance ?? null,
+      allowedProjectIds,
     });
 
     return reply.code(201).send({ enrollment });
@@ -49,7 +54,14 @@ export const enrollmentRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid query', 400, parsedQuery.error.flatten());
     }
 
-    const data = await listEnrollments(parsedQuery.data);
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
+    const data = await listEnrollments({
+      ...parsedQuery.data,
+      allowedProjectIds,
+    });
 
     return {
       data,
@@ -74,7 +86,11 @@ export const enrollmentRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid body', 400, parsedBody.error.flatten());
     }
 
-    const enrollment = await updateEnrollment(parsedParams.data.id, parsedBody.data);
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
+    const enrollment = await updateEnrollment(parsedParams.data.id, { ...parsedBody.data, allowedProjectIds });
     return { enrollment };
   });
 
@@ -91,12 +107,17 @@ export const enrollmentRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid body', 400, parsedBody.error.flatten());
     }
 
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
     const result = await recordAttendance({
       enrollmentId: parsedParams.data.id,
       date: parsedBody.data.date,
       present: parsedBody.data.present,
       justification: parsedBody.data.justification ?? null,
       recordedBy: request.user?.sub,
+      allowedProjectIds,
     });
 
     return reply.code(201).send(result);
@@ -115,10 +136,15 @@ export const enrollmentRoutes: FastifyPluginAsync = async (app) => {
       throw new AppError('Invalid query', 400, parsedQuery.error.flatten());
     }
 
+    const allowedProjectIds = request.user.projectScopes && request.user.projectScopes.length > 0
+      ? request.user.projectScopes
+      : null;
+
     const attendance = await getAttendance({
       enrollmentId: parsedParams.data.id,
       startDate: parsedQuery.data.startDate,
       endDate: parsedQuery.data.endDate,
+      allowedProjectIds,
     });
 
     return { data: attendance };

--- a/src/modules/forms/types.ts
+++ b/src/modules/forms/types.ts
@@ -57,6 +57,7 @@ export type ListSubmissionsFilters = {
   formType?: string;
   limit: number;
   offset: number;
+  allowedProjectIds?: string[] | null;
 };
 
 export type CreateSubmissionInput = {

--- a/tests/enrollments.service.test.ts
+++ b/tests/enrollments.service.test.ts
@@ -91,13 +91,14 @@ describe('recordAttendance service', () => {
       justification: null,
     });
 
-    expect(upsertAttendanceMock).toHaveBeenCalledWith({
+    expect(upsertAttendanceMock).toHaveBeenCalledWith(expect.objectContaining({
       enrollmentId: enrollment.id,
       date: '2024-06-01',
       present: true,
       justification: null,
       recordedBy: undefined,
-    });
+      allowedProjectIds: null,
+    }));
     expect(result.summary).toEqual(enrollment.attendance);
     expect(result.risk).toEqual({
       status: 'ok',

--- a/tests/integration/project-scope-guards.test.ts
+++ b/tests/integration/project-scope-guards.test.ts
@@ -1,0 +1,224 @@
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { hash } from 'bcryptjs';
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 30000 });
+
+const { mem, adapter } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { newDb } = require('pg-mem');
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  const adapter = db.adapters.createPg();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { randomUUID: randomUUIDFn } = require('crypto');
+  db.public.registerFunction({
+    name: 'gen_random_uuid',
+    returns: 'uuid',
+    implementation: () => randomUUIDFn(),
+  });
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret-imm-123456789012345678901234567890';
+  process.env.JWT_EXPIRES_IN = '1h';
+  process.env.DATABASE_URL = 'postgres://imm:test@localhost:5432/imm_test';
+  process.env.LOG_LEVEL = 'debug';
+  process.env.SEED_DEMO_DATA = 'false';
+  return { mem: db, adapter };
+});
+
+vi.mock('pg', () => ({
+  Pool: adapter.Pool,
+  Client: adapter.Client,
+}));
+
+import { seedDatabase } from '../../src/scripts/seed';
+import { pool } from '../../src/db/pool';
+import { createApp } from '../../src/app';
+
+let app: FastifyInstance;
+
+async function loadSchema() {
+  const files = [
+    path.join(__dirname, '../../artifacts/sql/0001_initial.sql'),
+    path.join(__dirname, '../../artifacts/sql/0002_rbac_and_profiles.sql'),
+  ];
+
+  for (const sqlPath of files) {
+    const schemaSql = fs.readFileSync(sqlPath, 'utf8');
+    const statements = schemaSql
+      .replace(/--.*$/gm, '')
+      .split(';')
+      .map((statement) => statement.trim())
+      .filter(Boolean)
+      .filter((statement) => {
+        const lower = statement.toLowerCase();
+        return !lower.startsWith('create extension') && !lower.startsWith('create index');
+      });
+
+    for (const statement of statements) {
+      mem.public.none(statement);
+    }
+  }
+}
+
+async function login(appInstance: FastifyInstance, email: string, password: string): Promise<string> {
+  const response = await appInstance.inject({
+    method: 'POST',
+    url: '/auth/login',
+    payload: { email, password },
+  });
+
+  expect(response.statusCode).toBe(200);
+  return response.json().token as string;
+}
+
+beforeAll(async () => {
+  await loadSchema();
+  await seedDatabase();
+  app = await createApp();
+  await app.ready();
+});
+
+afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
+  await pool.end();
+});
+
+beforeEach(async () => {
+  await pool.query('delete from attendance');
+  await pool.query('delete from enrollments');
+  await pool.query('delete from cohorts');
+  await pool.query('delete from projects');
+  await pool.query('delete from beneficiaries');
+  await pool.query("delete from user_roles where user_id in (select id from users where email like 'educadora.scope%@imm.local')");
+  await pool.query("delete from user_profiles where user_id in (select id from users where email like 'educadora.scope%@imm.local')");
+  await pool.query("delete from users where email like 'educadora.scope%@imm.local'");
+});
+
+describe('project scope guards', () => {
+  it('prevents scoped users from accessing projects outside their delegation', async () => {
+    const projectAllowedId = randomUUID();
+    const projectDeniedId = randomUUID();
+
+    await pool.query("insert into projects (id, name) values ($1, 'Projeto Permitido')", [projectAllowedId]);
+    await pool.query("insert into projects (id, name) values ($1, 'Projeto Bloqueado')", [projectDeniedId]);
+
+    const cohortAllowedId = randomUUID();
+    const cohortDeniedId = randomUUID();
+
+    await pool.query(
+      `insert into cohorts (id, project_id, code, weekday, shift, start_time, end_time, capacity, location)
+         values ($1, $2, 'COHORT-A', 1, 'manha', '08:00', '10:00', 20, 'Sala 1')`,
+      [cohortAllowedId, projectAllowedId],
+    );
+
+    await pool.query(
+      `insert into cohorts (id, project_id, code, weekday, shift, start_time, end_time, capacity, location)
+         values ($1, $2, 'COHORT-B', 2, 'tarde', '14:00', '16:00', 18, 'Sala 2')`,
+      [cohortDeniedId, projectDeniedId],
+    );
+
+    const beneficiaryAllowedId = randomUUID();
+    const beneficiaryDeniedId = randomUUID();
+
+    await pool.query(
+      `insert into beneficiaries (id, full_name) values ($1, 'Beneficiária Permitida')`,
+      [beneficiaryAllowedId],
+    );
+    await pool.query(
+      `insert into beneficiaries (id, full_name) values ($1, 'Beneficiária Restrita')`,
+      [beneficiaryDeniedId],
+    );
+
+    await pool.query(
+      `insert into enrollments (id, beneficiary_id, cohort_id, status, enrolled_at)
+         values ($1, $2, $3, 'active', current_date)` ,
+      [randomUUID(), beneficiaryAllowedId, cohortAllowedId],
+    );
+
+    const deniedEnrollmentId = randomUUID();
+    await pool.query(
+      `insert into enrollments (id, beneficiary_id, cohort_id, status, enrolled_at)
+         values ($1, $2, $3, 'active', current_date)` ,
+      [deniedEnrollmentId, beneficiaryDeniedId, cohortDeniedId],
+    );
+
+    const educatorPassword = 'Scope123!';
+    const educatorHash = await hash(educatorPassword, 12);
+    const educatorId = randomUUID();
+
+    await pool.query(
+      `insert into users (id, name, email, password_hash)
+         values ($1, 'Educadora Escopo', 'educadora.scope@imm.local', $2)` ,
+      [educatorId, educatorHash],
+    );
+    await pool.query(
+      `insert into user_profiles (user_id, display_name) values ($1, 'Educadora Escopo')`,
+      [educatorId],
+    );
+
+    const { rows: roleRows } = await pool.query<{ id: number }>(`select id from roles where slug = 'educadora'`);
+    const roleId = roleRows[0]?.id;
+    expect(roleId).toBeDefined();
+
+    await pool.query(
+      `insert into user_roles (id, user_id, role_id, project_id)
+         values ($1, $2, $3, $4)` ,
+      [randomUUID(), educatorId, roleId, projectAllowedId],
+    );
+
+    const token = await login(app, 'educadora.scope@imm.local', educatorPassword);
+
+    const allowedResponse = await app.inject({
+      method: 'GET',
+      url: `/enrollments?projectId=${projectAllowedId}`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(allowedResponse.statusCode).toBe(200);
+    const allowedBody = allowedResponse.json();
+    expect(Array.isArray(allowedBody.data)).toBe(true);
+    expect(allowedBody.data).toHaveLength(1);
+    expect(allowedBody.data[0].projectId).toBe(projectAllowedId);
+
+    const forbiddenResponse = await app.inject({
+      method: 'GET',
+      url: `/enrollments?projectId=${projectDeniedId}`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(forbiddenResponse.statusCode).toBe(403);
+
+    const beneficiariesResponse = await app.inject({
+      method: 'GET',
+      url: '/beneficiaries',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(beneficiariesResponse.statusCode).toBe(200);
+    const beneficiariesBody = beneficiariesResponse.json();
+    const beneficiaryNames = (beneficiariesBody.data as Array<{ fullName: string }>).map((item) => item.fullName);
+    expect(beneficiaryNames).toContain('Beneficiária Permitida');
+    expect(beneficiaryNames).not.toContain('Beneficiária Restrita');
+
+    const deniedBeneficiaryView = await app.inject({
+      method: 'GET',
+      url: `/beneficiaries/${beneficiaryDeniedId}`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(deniedBeneficiaryView.statusCode).toBe(404);
+
+    const deniedEnrollmentAttendance = await app.inject({
+      method: 'GET',
+      url: `/enrollments/${deniedEnrollmentId}/attendance`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(deniedEnrollmentAttendance.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- replace array-based ANY filters with dynamically generated IN clauses across enrollment, beneficiary, form, and certificate repositories so project scopes work under pg-mem as well as Postgres
- ensure scoped lookups reuse the new helpers and keep enrollment/beneficiary access constrained to allowed project IDs
- add an integration test that verifies scoped users can read only delegated projects and receive 403/404 for restricted data

## Testing
- `LOG_LEVEL=error npx vitest run tests/integration/project-scope-guards.test.ts`
- `npx vitest run tests/enrollments.service.test.ts`
- `npx vitest run tests/certificates.service.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d3cdabf86c8324b30d68046cd633f8