### PR TITLE
feat: enhance notification orchestration

### DIFF
--- a/src/modules/notifications/adapters/base-adapter.ts
+++ b/src/modules/notifications/adapters/base-adapter.ts
@@ -1,0 +1,22 @@
+import { performance } from 'node:perf_hooks';
+import type { NotificationChannel } from '../types';
+import { NotificationMetrics } from '../metrics';
+
+export abstract class BaseNotificationAdapter<TPayload> {
+  protected constructor(
+    protected readonly channel: NotificationChannel,
+    private readonly metrics: NotificationMetrics,
+  ) {}
+
+  protected async executeWithMetrics(handler: () => Promise<void>) {
+    const start = performance.now();
+    try {
+      await handler();
+      const durationMs = performance.now() - start;
+      this.metrics.recordSuccess(this.channel, durationMs);
+    } catch (error) {
+      this.metrics.recordFailure(this.channel);
+      throw error;
+    }
+  }
+}

--- a/src/modules/notifications/adapters/email-adapter.ts
+++ b/src/modules/notifications/adapters/email-adapter.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto';
+import { logger } from '../../../config/logger';
+import type { NotificationEvent } from '../types';
+import { BaseNotificationAdapter } from './base-adapter';
+import { NotificationMetrics } from '../metrics';
+
+export type EmailNotificationPayload = {
+  recipients: string[];
+  subject: string;
+  body: string;
+  eventType: NotificationEvent['type'];
+  eventId: string;
+};
+
+export type EmailDispatchRecord = EmailNotificationPayload & {
+  messageId: string;
+  dispatchedAt: string;
+};
+
+export class EmailNotificationAdapter extends BaseNotificationAdapter<EmailNotificationPayload> {
+  private readonly dispatchHistory: EmailDispatchRecord[] = [];
+
+  constructor(
+    metrics: NotificationMetrics,
+    private readonly sender: string,
+  ) {
+    super('email', metrics);
+  }
+
+  async send(payload: EmailNotificationPayload): Promise<void> {
+    await this.executeWithMetrics(async () => {
+      const record: EmailDispatchRecord = {
+        ...payload,
+        messageId: randomUUID(),
+        dispatchedAt: new Date().toISOString(),
+      };
+
+      this.dispatchHistory.push(record);
+      logger.info({
+        channel: 'email',
+        from: this.sender,
+        to: payload.recipients,
+        subject: payload.subject,
+        eventId: payload.eventId,
+        eventType: payload.eventType,
+        messageId: record.messageId,
+      }, 'Email notification dispatched');
+    });
+  }
+
+  getHistory(): ReadonlyArray<EmailDispatchRecord> {
+    return this.dispatchHistory;
+  }
+
+  reset() {
+    this.dispatchHistory.length = 0;
+  }
+}

--- a/src/modules/notifications/adapters/webhook-adapter.ts
+++ b/src/modules/notifications/adapters/webhook-adapter.ts
@@ -1,0 +1,107 @@
+import { createHmac } from 'node:crypto';
+import { logger } from '../../../config/logger';
+import type { NotificationEvent } from '../types';
+import type { WebhookSubscription } from '../webhook-registry';
+import { BaseNotificationAdapter } from './base-adapter';
+import { NotificationMetrics } from '../metrics';
+
+export type WebhookJobPayload = {
+  subscription: WebhookSubscription;
+  event: NotificationEvent & { triggeredAt: string; id: string };
+  timeoutMs: number;
+  defaultSecret: string | null;
+};
+
+export class WebhookNotificationAdapter extends BaseNotificationAdapter<WebhookJobPayload> {
+  private readonly deliveredKeys = new Set<string>();
+
+  constructor(metrics: NotificationMetrics) {
+    super('webhook', metrics);
+  }
+
+  async send(payload: WebhookJobPayload): Promise<void> {
+    const fetchFn: typeof fetch | undefined = (globalThis as any).fetch;
+    if (!fetchFn) {
+      throw new Error('Fetch API not available for webhook dispatch');
+    }
+
+    const deliveryKey = this.buildDeliveryKey(payload.subscription.id, payload.event.id);
+    if (this.deliveredKeys.has(deliveryKey)) {
+      logger.info({
+        channel: 'webhook',
+        eventId: payload.event.id,
+        webhookId: payload.subscription.id,
+      }, 'Skipping webhook dispatch because it was already delivered');
+      return;
+    }
+
+    await this.executeWithMetrics(async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), payload.timeoutMs);
+
+      try {
+        const requestBody = JSON.stringify({
+          id: payload.event.id,
+          event: payload.event.type,
+          triggeredAt: payload.event.triggeredAt,
+          data: payload.event.data,
+        });
+
+        const timestamp = new Date().toISOString();
+        const deliveryId = deliveryKey;
+        const headers: Record<string, string> = {
+          'content-type': 'application/json',
+          'x-imm-event': payload.event.type,
+          'x-imm-webhook-id': payload.subscription.id,
+          'x-imm-webhook-delivery': deliveryId,
+          'x-imm-webhook-timestamp': timestamp,
+        };
+
+        const secret = payload.subscription.secret ?? payload.defaultSecret;
+        if (secret) {
+          headers['x-imm-webhook-signature'] = this.signPayload(secret, timestamp, requestBody);
+        }
+
+        const response = await fetchFn(payload.subscription.url, {
+          method: 'POST',
+          headers,
+          body: requestBody,
+          signal: controller.signal,
+        });
+
+        if (!response || typeof response.ok !== 'boolean') {
+          throw new Error('Webhook dispatch returned an invalid response');
+        }
+
+        if (!response.ok) {
+          const status = typeof response.status === 'number' ? response.status : 'unknown';
+          throw new Error(`Webhook dispatch failed with status ${status}`);
+        }
+
+        this.deliveredKeys.add(deliveryKey);
+        logger.info({
+          channel: 'webhook',
+          eventId: payload.event.id,
+          webhookId: payload.subscription.id,
+          url: payload.subscription.url,
+        }, 'Webhook notification dispatched');
+      } finally {
+        clearTimeout(timeout);
+      }
+    });
+  }
+
+  reset() {
+    this.deliveredKeys.clear();
+  }
+
+  private buildDeliveryKey(subscriptionId: string, eventId: string): string {
+    return `${subscriptionId}:${eventId}`;
+  }
+
+  private signPayload(secret: string, timestamp: string, body: string): string {
+    const hmac = createHmac('sha256', secret);
+    hmac.update(`${timestamp}.${body}`);
+    return `sha256=${hmac.digest('hex')}`;
+  }
+}

--- a/src/modules/notifications/adapters/whatsapp-adapter.ts
+++ b/src/modules/notifications/adapters/whatsapp-adapter.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto';
+import { logger } from '../../../config/logger';
+import type { NotificationEvent } from '../types';
+import { BaseNotificationAdapter } from './base-adapter';
+import { NotificationMetrics } from '../metrics';
+
+export type WhatsAppNotificationPayload = {
+  numbers: string[];
+  message: string;
+  eventType: NotificationEvent['type'];
+  eventId: string;
+};
+
+export type WhatsAppDispatchRecord = WhatsAppNotificationPayload & {
+  messageId: string;
+  dispatchedAt: string;
+};
+
+export class WhatsAppNotificationAdapter extends BaseNotificationAdapter<WhatsAppNotificationPayload> {
+  private readonly dispatchHistory: WhatsAppDispatchRecord[] = [];
+
+  constructor(metrics: NotificationMetrics) {
+    super('whatsapp', metrics);
+  }
+
+  async send(payload: WhatsAppNotificationPayload): Promise<void> {
+    await this.executeWithMetrics(async () => {
+      const record: WhatsAppDispatchRecord = {
+        ...payload,
+        messageId: randomUUID(),
+        dispatchedAt: new Date().toISOString(),
+      };
+
+      this.dispatchHistory.push(record);
+      logger.info({
+        channel: 'whatsapp',
+        to: payload.numbers,
+        eventId: payload.eventId,
+        eventType: payload.eventType,
+        messageId: record.messageId,
+      }, 'WhatsApp notification dispatched');
+    });
+  }
+
+  getHistory(): ReadonlyArray<WhatsAppDispatchRecord> {
+    return this.dispatchHistory;
+  }
+
+  reset() {
+    this.dispatchHistory.length = 0;
+  }
+}

--- a/src/modules/notifications/metrics.ts
+++ b/src/modules/notifications/metrics.ts
@@ -1,0 +1,98 @@
+import type { NotificationChannel } from './types';
+
+export type ChannelMetricSnapshot = {
+  delivered: number;
+  failed: number;
+  duplicates: number;
+  deadLettered: number;
+  retries: number;
+  averageProcessingTimeMs: number;
+};
+
+export type NotificationMetricsSnapshot = Record<NotificationChannel, ChannelMetricSnapshot>;
+
+type ChannelMetricsState = {
+  delivered: number;
+  failed: number;
+  duplicates: number;
+  deadLettered: number;
+  retries: number;
+  totalProcessingTimeMs: number;
+};
+
+function createEmptyState(): ChannelMetricsState {
+  return {
+    delivered: 0,
+    failed: 0,
+    duplicates: 0,
+    deadLettered: 0,
+    retries: 0,
+    totalProcessingTimeMs: 0,
+  };
+}
+
+export class NotificationMetrics {
+  private readonly state: Record<NotificationChannel, ChannelMetricsState> = {
+    email: createEmptyState(),
+    whatsapp: createEmptyState(),
+    webhook: createEmptyState(),
+  };
+
+  recordSuccess(channel: NotificationChannel, durationMs: number) {
+    const metrics = this.state[channel];
+    metrics.delivered += 1;
+    metrics.totalProcessingTimeMs += durationMs;
+  }
+
+  recordFailure(channel: NotificationChannel) {
+    this.state[channel].failed += 1;
+  }
+
+  recordDuplicate(channel: NotificationChannel) {
+    this.state[channel].duplicates += 1;
+  }
+
+  recordDeadLetter(channel: NotificationChannel) {
+    this.state[channel].deadLettered += 1;
+  }
+
+  recordRetry(channel: NotificationChannel) {
+    this.state[channel].retries += 1;
+  }
+
+  getSnapshot(): NotificationMetricsSnapshot {
+    return {
+      email: this.toSnapshot('email'),
+      whatsapp: this.toSnapshot('whatsapp'),
+      webhook: this.toSnapshot('webhook'),
+    };
+  }
+
+  reset() {
+    for (const channel of Object.keys(this.state) as NotificationChannel[]) {
+      const metrics = this.state[channel];
+      metrics.delivered = 0;
+      metrics.failed = 0;
+      metrics.duplicates = 0;
+      metrics.deadLettered = 0;
+      metrics.retries = 0;
+      metrics.totalProcessingTimeMs = 0;
+    }
+  }
+
+  private toSnapshot(channel: NotificationChannel): ChannelMetricSnapshot {
+    const metrics = this.state[channel];
+    const averageProcessingTimeMs = metrics.delivered > 0
+      ? metrics.totalProcessingTimeMs / metrics.delivered
+      : 0;
+
+    return {
+      delivered: metrics.delivered,
+      failed: metrics.failed,
+      duplicates: metrics.duplicates,
+      deadLettered: metrics.deadLettered,
+      retries: metrics.retries,
+      averageProcessingTimeMs,
+    };
+  }
+}

--- a/src/modules/notifications/types.ts
+++ b/src/modules/notifications/types.ts
@@ -1,6 +1,10 @@
-export type EnrollmentCreatedEvent = {
-  type: 'enrollment.created';
+type NotificationEventBase = {
+  id?: string;
   triggeredAt?: string;
+};
+
+export type EnrollmentCreatedEvent = NotificationEventBase & {
+  type: 'enrollment.created';
   data: {
     enrollmentId: string;
     beneficiaryId: string;
@@ -12,11 +16,11 @@ export type EnrollmentCreatedEvent = {
     status: string;
     enrolledAt: string;
   };
+  };
 };
 
-export type AttendanceRecordedEvent = {
+export type AttendanceRecordedEvent = NotificationEventBase & {
   type: 'attendance.recorded';
-  triggeredAt?: string;
   data: {
     attendanceId: string;
     enrollmentId: string;
@@ -24,11 +28,11 @@ export type AttendanceRecordedEvent = {
     present: boolean;
     justification: string | null;
   };
+  };
 };
 
-export type AttendanceLowAttendanceEvent = {
+export type AttendanceLowAttendanceEvent = NotificationEventBase & {
   type: 'attendance.low_attendance';
-  triggeredAt?: string;
   data: {
     enrollmentId: string;
     beneficiaryId: string;
@@ -42,11 +46,11 @@ export type AttendanceLowAttendanceEvent = {
     totalSessions: number;
     presentSessions: number;
   };
+  };
 };
 
-export type ConsentRecordedEvent = {
+export type ConsentRecordedEvent = NotificationEventBase & {
   type: 'consent.recorded';
-  triggeredAt?: string;
   data: {
     consentId: string;
     beneficiaryId: string;
@@ -56,11 +60,11 @@ export type ConsentRecordedEvent = {
     grantedAt: string;
     revokedAt: string | null;
   };
+  };
 };
 
-export type ConsentUpdatedEvent = {
+export type ConsentUpdatedEvent = NotificationEventBase & {
   type: 'consent.updated';
-  triggeredAt?: string;
   data: {
     consentId: string;
     beneficiaryId: string;
@@ -70,11 +74,11 @@ export type ConsentUpdatedEvent = {
     grantedAt: string;
     revokedAt: string | null;
   };
+  };
 };
 
-export type ActionItemDueSoonEvent = {
+export type ActionItemDueSoonEvent = NotificationEventBase & {
   type: 'action_item.due_soon';
-  triggeredAt?: string;
   data: {
     actionPlanId: string;
     actionItemId: string;
@@ -86,11 +90,11 @@ export type ActionItemDueSoonEvent = {
     status: string;
     dueInDays: number;
   };
+  };
 };
 
-export type ActionItemOverdueEvent = {
+export type ActionItemOverdueEvent = NotificationEventBase & {
   type: 'action_item.overdue';
-  triggeredAt?: string;
   data: {
     actionPlanId: string;
     actionItemId: string;
@@ -102,11 +106,11 @@ export type ActionItemOverdueEvent = {
     status: string;
     overdueByDays: number;
   };
+  };
 };
 
-export type PasswordResetRequestedEvent = {
+export type PasswordResetRequestedEvent = NotificationEventBase & {
   type: 'auth.password_reset_requested';
-  triggeredAt?: string;
   data: {
     email: string;
     name: string;

--- a/src/shared/job-queue.ts
+++ b/src/shared/job-queue.ts
@@ -11,24 +11,27 @@ export interface JobQueueOptions<T> {
   maxAttempts?: number;
   backoffMs?: number;
   onError?: (error: unknown, job: Job<T>) => void;
+  onAttemptFailure?: (error: unknown, job: Job<T>) => void;
 }
 
 const defaultOptions = {
   concurrency: 1,
   maxAttempts: 3,
   backoffMs: 1000,
-} satisfies Required<Omit<JobQueueOptions<unknown>, 'onError'>>;
+} satisfies Required<Omit<JobQueueOptions<unknown>, 'onError' | 'onAttemptFailure'>>;
 
 export class JobQueue<T> {
   private readonly handler: (payload: T) => Promise<void> | void;
 
-  private readonly options: Required<typeof defaultOptions> & Pick<JobQueueOptions<T>, 'onError'>;
+  private readonly options: Required<typeof defaultOptions> & Pick<JobQueueOptions<T>, 'onError' | 'onAttemptFailure'>;
 
   private readonly queue: Job<T>[] = [];
 
   private activeCount = 0;
 
   private idleResolvers: Array<() => void> = [];
+
+  private pendingRetryCount = 0;
 
   constructor(handler: (payload: T) => Promise<void> | void, options?: JobQueueOptions<T>) {
     this.handler = handler;
@@ -51,7 +54,7 @@ export class JobQueue<T> {
   }
 
   async onIdle(): Promise<void> {
-    if (this.queue.length === 0 && this.activeCount === 0) {
+    if (this.queue.length === 0 && this.activeCount === 0 && this.pendingRetryCount === 0) {
       return;
     }
 
@@ -89,16 +92,32 @@ export class JobQueue<T> {
         this.activeCount -= 1;
         job.attempts += 1;
 
+        const invokeAttemptFailure = () => {
+          if (this.options.onAttemptFailure) {
+            try {
+              this.options.onAttemptFailure(error, job);
+            } catch {
+              // ignore errors thrown by attempt failure handler
+            }
+          }
+        };
+
         if (job.attempts < this.options.maxAttempts) {
+          invokeAttemptFailure();
+          this.pendingRetryCount += 1;
           setTimeout(() => {
+            this.pendingRetryCount -= 1;
             this.queue.push(job);
             this.process();
           }, this.options.backoffMs);
-        } else if (this.options.onError) {
-          try {
-            this.options.onError(error, job);
-          } catch {
-            // ignore errors thrown by onError handler
+        } else {
+          invokeAttemptFailure();
+          if (this.options.onError) {
+            try {
+              this.options.onError(error, job);
+            } catch {
+              // ignore errors thrown by onError handler
+            }
           }
         }
 
@@ -107,7 +126,7 @@ export class JobQueue<T> {
   }
 
   private maybeResolveIdle() {
-    if (this.queue.length === 0 && this.activeCount === 0) {
+    if (this.queue.length === 0 && this.activeCount === 0 && this.pendingRetryCount === 0) {
       while (this.idleResolvers.length > 0) {
         const resolve = this.idleResolvers.shift();
         resolve?.();


### PR DESCRIPTION
## Summary
- restructure the notification service to orchestrate channel adapters with metrics, deduplication, and a dead-letter queue
- add email, WhatsApp, and webhook adapters with delivery history, metrics instrumentation, and signed webhook payloads that guard against replay
- extend notification typing, job queue support, and tests to cover idempotency, metrics, and DLQ retry scenarios

## Testing
- npm test *(hangs on analytics suites after other suites pass)*
- npx vitest run tests/analytics.service.test.ts *(hangs in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eb4ab3d88324a2ad0588ff21a725