### PR TITLE
feat(forms): add versioned schema registry and signature evidence

### DIFF
--- a/artifacts/json_schemas/payloads/payload.anamnese_social.demo.json
+++ b/artifacts/json_schemas/payloads/payload.anamnese_social.demo.json
@@ -1,0 +1,133 @@
+{
+  "identificacao": {
+    "nome": "Maria das Dores Silva",
+    "nome_social": "Maria Silva",
+    "data_nascimento": "1989-07-12",
+    "idade": 35,
+    "estado_civil": "Solteira",
+    "genero": "Feminino",
+    "responsavel_familiar": "Maria das Dores Silva",
+    "telefone_principal": "+55 21 98888-7777",
+    "telefones_secundarios": [
+      "+55 21 97777-6666"
+    ],
+    "email": "maria.silva@example.com",
+    "endereco": {
+      "logradouro": "Rua das Flores",
+      "numero": "120",
+      "complemento": "Casa 02",
+      "bairro": "Bom Jardim",
+      "cidade": "São Gonçalo",
+      "estado": "RJ",
+      "cep": "24710-000"
+    }
+  },
+  "documentos": {
+    "cpf": "123.456.789-00",
+    "rg": "12.345.678-9",
+    "nis": "12345678900",
+    "cns": "98765432100",
+    "outros": [
+      "Carteira de Trabalho"
+    ]
+  },
+  "composicao_familiar": [
+    {
+      "nome": "João da Silva",
+      "parentesco": "Filho",
+      "idade": 12,
+      "escolaridade": "Fundamental",
+      "ocupacao": "Estudante",
+      "renda_mensal": 0,
+      "observacoes": "Participa do reforço escolar"
+    },
+    {
+      "nome": "Ana Souza",
+      "parentesco": "Mãe",
+      "idade": 62,
+      "escolaridade": "Ensino médio",
+      "ocupacao": "Aposentada",
+      "renda_mensal": 1320
+    }
+  ],
+  "escolaridade_formacao": {
+    "nivel": "Ensino Médio Completo",
+    "situacao": "Concluído",
+    "alfabetizado": true,
+    "cursos_realizados": [
+      "Artesanato em tecido",
+      "Gestão financeira básica"
+    ],
+    "dificuldades_aprendizagem": "Relata dificuldade com matemática básica"
+  },
+  "trabalho_renda": {
+    "ocupacao_principal": "Artesã",
+    "situacao_trabalho": "Autônoma",
+    "renda_mensal": 1800,
+    "fonte_renda": "Venda de artesanato",
+    "beneficios_sociais": [
+      "Bolsa Família"
+    ],
+    "despesas_mensais": {
+      "moradia": 700,
+      "alimentacao": 500,
+      "saude": 150,
+      "educacao": 80,
+      "transporte": 120,
+      "outros": 200
+    }
+  },
+  "saude": {
+    "possui_doenca_cronica": true,
+    "descricao_doencas": "Hipertensão controlada",
+    "acompanhamento_saude": [
+      "UBS Bom Jardim"
+    ],
+    "possui_deficiencia": false,
+    "uso_medicamentos": true,
+    "descricao_medicamentos": "Losartana 50mg",
+    "servicos_saude_utilizados": [
+      "UBS",
+      "Clínica da Família"
+    ]
+  },
+  "habitacao": {
+    "tipo_moradia": "Casa de alvenaria",
+    "situacao_moradia": "Alugada",
+    "numero_comodos": 4,
+    "material_predominante": "Alvenaria",
+    "numero_moradores": 3,
+    "servicos_basicos": [
+      "Água encanada",
+      "Energia elétrica",
+      "Coleta de lixo"
+    ],
+    "risco_moradia": "Área de alagamento",
+    "observacoes": "Rua com acesso precário em dias de chuva"
+  },
+  "rede_apoio": {
+    "participa_grupo_comunitario": true,
+    "grupos": [
+      "Associação de Artesãs do bairro"
+    ],
+    "instituicoes_acompanhamento": [
+      {
+        "nome": "CRAS Jardim Catarina",
+        "tipo": "CRAS",
+        "responsavel": "Assistente social Joana"
+      }
+    ]
+  },
+  "situacao_violencia": {
+    "historico_violencia": false,
+    "tipos_violencia": [],
+    "rede_protecao_acionada": [],
+    "medidas_protecao": null
+  },
+  "expectativas_objetivos": {
+    "objetivos_curto_prazo": "Aumentar a renda com novas técnicas de artesanato",
+    "objetivos_medio_prazo": "Regularizar documentação e ampliar rede de clientes",
+    "objetivos_longo_prazo": "Abrir um ateliê comunitário",
+    "observacoes_tecnicas": "Beneficiária engajada e com boa rede comunitária"
+  }
+}

--- a/artifacts/json_schemas/payloads/payload.consentimentos.demo.json
+++ b/artifacts/json_schemas/payloads/payload.consentimentos.demo.json
@@ -1,0 +1,41 @@
+{
+  "dados_titular": {
+    "nome": "Maria das Dores Silva",
+    "documentos": {
+      "cpf": "123.456.789-00"
+    },
+    "contatos": {
+      "telefone": "+55 21 98888-7777",
+      "email": "maria.silva@example.com"
+    }
+  },
+  "consentimentos": [
+    {
+      "tipo": "uso_imagem",
+      "descricao": "Autorizo o uso da minha imagem em materiais institucionais",
+      "aceite": true,
+      "validade": "2025-12-31",
+      "canal": "Tablet",
+      "responsavel": "Ana Souza",
+      "observacoes": "Consentimento coletado durante evento de integração"
+    },
+    {
+      "tipo": "compartilhamento_dados",
+      "descricao": "Autorizo o compartilhamento dos meus dados com parceiros do projeto",
+      "aceite": false,
+      "motivo_recusa": "Prefere validar caso a caso",
+      "canal": "Tablet"
+    }
+  ],
+  "testemunhas": [
+    {
+      "nome": "João Pereira",
+      "relacao": "Educador social"
+    }
+  ],
+  "registro_evidencias": {
+    "local": "Sede Instituto Move Marias",
+    "capturado_por": "Ana Souza",
+    "observacoes": "Beneficiária solicitou revisão em 12 meses"
+  }
+}

--- a/artifacts/json_schemas/payloads/payload.declaracao_recibo.demo.json
+++ b/artifacts/json_schemas/payloads/payload.declaracao_recibo.demo.json
@@ -1,0 +1,25 @@
+{
+  "declaracao_comparecimento": {
+    "cpf": "123.456.789-00",
+    "paedi": "PAEDI-2024-045",
+    "local": "Sede Instituto Move Marias",
+    "data": "2024-08-02",
+    "hora_inicio": "09:00",
+    "hora_fim": "11:30",
+    "responsavel": "Patrícia Lima",
+    "atividades_realizadas": ["Oficina de gastronomia social", "Atendimento psicossocial"],
+    "observacoes": "Beneficiária participou integralmente das atividades previstas."
+  },
+  "recibo_beneficio": {
+    "cpf": "123.456.789-00",
+    "paedi": "PAEDI-2024-045",
+    "descricao_beneficio": "Entrega de kit alimentação e auxílio transporte",
+    "itens": [
+      {"descricao": "Cesta básica", "quantidade": 1, "valor_unitario": 150.0},
+      {"descricao": "Vale transporte", "quantidade": 8, "valor_unitario": 4.50}
+    ],
+    "data": "2024-08-02",
+    "responsavel_registro": "Ana Paula Santos",
+    "observacoes": "Beneficiária assinou digitalmente o comprovante"
+  }
+}

--- a/artifacts/json_schemas/payloads/payload.ficha_evolucao.demo.json
+++ b/artifacts/json_schemas/payloads/payload.ficha_evolucao.demo.json
@@ -1,0 +1,59 @@
+{
+  "identificacao_atendimento": {
+    "beneficiaria_nome": "Maria das Dores Silva",
+    "beneficiaria_id": "demo-beneficiaria-001",
+    "data_atendimento": "2024-08-05",
+    "horario_inicio": "14:00",
+    "horario_termino": "15:20",
+    "profissional_responsavel": "Carla Souza",
+    "funcao_profissional": "Assistente Social",
+    "tipo_atendimento": "Atendimento individual",
+    "local_atendimento": "Sala de escuta",
+    "participantes": ["Maria das Dores Silva"],
+    "modalidade": "Presencial"
+  },
+  "descricao_atendimento": {
+    "relato_sessao": "A beneficiária relatou avanços na organização financeira doméstica e trouxe dúvidas sobre acesso a microcrédito.",
+    "contexto": "Atendimento de acompanhamento mensal",
+    "observacoes_profissional": "Notou-se melhora significativa na autoestima."
+  },
+  "avaliacao": {
+    "indicadores": [
+      {
+        "descricao": "Adesão às atividades propostas",
+        "escala": 4,
+        "comentario": "Participa de todas as oficinas previstas."
+      },
+      {
+        "descricao": "Desenvolvimento socioemocional",
+        "escala": 3,
+        "comentario": "Demonstra confiança crescente no grupo."
+      }
+    ],
+    "satisfacao_beneficiaria": 5,
+    "percepcoes": "Beneficiária relatou sentir-se acolhida pela equipe."
+  },
+  "encaminhamentos": {
+    "internos": [
+      {
+        "descricao": "Participar da roda de conversa sobre educação financeira",
+        "responsavel": "Equipe Social",
+        "prazo": "2024-08-20"
+      }
+    ],
+    "externos": [
+      {
+        "descricao": "Consulta com nutricionista na UBS",
+        "instituicao": "UBS Bom Jardim",
+        "contato": "(21) 3333-2222",
+        "prazo": "2024-09-01"
+      }
+    ]
+  },
+  "anexos_relevantes": [
+    {
+      "descricao": "Plano alimentar atualizado",
+      "url": "https://imm.local/anexos/plano-alimentar.pdf"
+    }
+  ]
+}

--- a/artifacts/json_schemas/payloads/payload.inscricao_projeto.demo.json
+++ b/artifacts/json_schemas/payloads/payload.inscricao_projeto.demo.json
@@ -1,0 +1,42 @@
+{
+  "identificacao": {
+    "nome": "Maria das Dores Silva",
+    "nome_social": "Maria Silva",
+    "data_nascimento": "1989-07-12",
+    "documentos": {
+      "cpf": "123.456.789-00",
+      "rg": "12.345.678-9"
+    },
+    "contatos": {
+      "telefone": "+55 21 98888-7777",
+      "email": "maria.silva@example.com"
+    }
+  },
+  "projeto": {
+    "nome": "Oficina de Gastronomia Social",
+    "dia_semana": "Terça-feira",
+    "turno": "Manhã",
+    "local": "Cozinha Escola",
+    "pre_requisitos": ["Disponibilidade semanal", "Interesse em geração de renda"]
+  },
+  "informacoes_socioeconomicas": {
+    "situacao_trabalho": "Autônoma",
+    "renda_familiar": 3120,
+    "moradia": "Alugada",
+    "participa_programas_sociais": true,
+    "programas_sociais": ["Bolsa Família"]
+  },
+  "acordos_convivencia": [
+    {
+      "slug": "pontualidade",
+      "descricao": "Compromisso com a assiduidade e pontualidade",
+      "aceite": true,
+      "observacoes": "Compreende que três faltas injustificadas implicam desligamento"
+    },
+    {
+      "slug": "uso_espaco",
+      "descricao": "Zelar pelo espaço físico e equipamentos",
+      "aceite": true
+    }
+  ]
+}

--- a/artifacts/json_schemas/payloads/payload.plano_acao.demo.json
+++ b/artifacts/json_schemas/payloads/payload.plano_acao.demo.json
@@ -1,0 +1,35 @@
+{
+  "objetivo_principal": "Gerar renda mínima de dois salários com produção artesanal",
+  "areas_prioritarias": ["Geração de renda", "Autonomia financeira"],
+  "acoes": [
+    {
+      "descricao": "Participar do curso de gestão financeira",
+      "responsavel": "Maria das Dores Silva",
+      "prazo": "2024-09-30",
+      "status": "em_andamento",
+      "suporte_instituto": "Mentorias quinzenais",
+      "observacoes": "Inscrição confirmada"
+    },
+    {
+      "descricao": "Criar catálogo digital dos produtos",
+      "responsavel": "Equipe de comunicação",
+      "prazo": "2024-10-15",
+      "status": "pendente",
+      "suporte_instituto": "Designer voluntário",
+      "observacoes": "Sessão de fotos agendada"
+    }
+  ],
+  "avaliacoes_semestrais": [
+    {
+      "data": "2024-12-15",
+      "avaliacao": "Beneficiária atingiu 70% da meta de renda",
+      "responsavel": "Assistente social"
+    }
+  ],
+  "assinaturas": {
+    "beneficiaria": "Maria das Dores Silva",
+    "tecnica": "Carla Souza",
+    "coordenacao": "Patrícia Lima"
+  },
+  "anexos": ["https://imm.local/anexos/plano-acao.pdf"]
+}

--- a/artifacts/json_schemas/payloads/payload.roda_da_vida.demo.json
+++ b/artifacts/json_schemas/payloads/payload.roda_da_vida.demo.json
@@ -1,0 +1,26 @@
+{
+  "data": "2024-08-10",
+  "pontuacoes": {
+    "qualidade_de_vida": 7,
+    "felicidade": 8,
+    "relacionamentos": 7,
+    "profissional": 6,
+    "lazer": 5,
+    "espiritualidade": 8,
+    "tempo_qualidade": 6,
+    "saude": 7,
+    "equilibrio_emocional": 6,
+    "recursos_financeiros": 5,
+    "carreira": 6,
+    "contribuicao_social": 8,
+    "familia": 7,
+    "amor": 8,
+    "vida_social": 6
+  },
+  "observacoes": "Beneficiária identificou necessidade de equilibrar tempo para lazer e investimentos no negócio próprio.",
+  "assinaturas": {
+    "beneficiaria": "Maria das Dores Silva",
+    "tecnica": "Fernanda Ramos"
+  },
+  "anexos": ["https://imm.local/anexos/roda-da-vida-2024-08.pdf"]
+}

--- a/artifacts/json_schemas/payloads/payload.visao_holistica.demo.json
+++ b/artifacts/json_schemas/payloads/payload.visao_holistica.demo.json
@@ -1,0 +1,13 @@
+{
+  "historia_vida": "Maria mudou-se para São Gonçalo há 6 anos buscando oportunidades de trabalho e apoio familiar. Passou por situações de violência doméstica e reconstruiu sua rede de apoio junto a vizinhas e coletivos locais.",
+  "rede_apoio": "Conta com apoio da mãe, da vizinha Dona Ana e do coletivo de artesãs do bairro.",
+  "contexto_atual": "Atualmente atua como artesã autônoma, com renda variável. Mora em casa alugada com o filho adolescente e a mãe idosa.",
+  "avaliacao_tecnica": "Identifica-se potencial para fortalecimento da autonomia financeira, necessidade de suporte psicológico contínuo e acompanhamento da saúde da mãe.",
+  "encaminhamento": {
+    "projeto": "Projeto Gastronomia Social",
+    "data": "2024-07-25",
+    "responsavel": "Carla Souza",
+    "assinatura": "Carla Souza"
+  },
+  "anexos": ["https://imm.local/anexos/visao-holistica-2024-07.pdf"]
+}

--- a/artifacts/json_schemas/registry.json
+++ b/artifacts/json_schemas/registry.json
@@ -1,0 +1,142 @@
+{
+  "registryVersion": "2024.10",
+  "updatedAt": "2024-10-01T00:00:00Z",
+  "forms": [
+    {
+      "type": "anamnese_social",
+      "title": "Anamnese Social",
+      "category": "acolhimento",
+      "description": "Instrumento padrão de acolhimento para levantar perfil socioeconômico, rede de apoio e demandas prioritárias da beneficiária.",
+      "owner": "servico_social",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": true,
+          "effectiveAt": "2024-02-01",
+          "schemaFile": "form.anamnese_social.v1.json",
+          "notes": "Versão inicial alinhada ao prontuário SUAS."
+        }
+      ]
+    },
+    {
+      "type": "ficha_evolucao",
+      "title": "Ficha de Evolução",
+      "category": "atendimentos",
+      "description": "Registro estruturado das evoluções de acompanhamento individual ou coletivo.",
+      "owner": "tecnica",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": true,
+          "effectiveAt": "2024-02-01",
+          "schemaFile": "form.ficha_evolucao.v1.json",
+          "notes": "Inclui identificação de atendimento, avaliação e encaminhamentos."
+        }
+      ]
+    },
+    {
+      "type": "plano_acao",
+      "title": "Plano de Ação Individual",
+      "category": "planejamento",
+      "description": "Plano individual com metas, responsáveis e indicadores de acompanhamento.",
+      "owner": "tecnica",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": false,
+          "effectiveAt": "2024-03-10",
+          "schemaFile": "form.plano_acao.v1.json",
+          "notes": "Estrutura inicial com metas SMART e monitoramento trimestral."
+        }
+      ]
+    },
+    {
+      "type": "inscricao_projeto",
+      "title": "Ficha de Inscrição de Projeto",
+      "category": "cadastro",
+      "description": "Formulário para inscrição das beneficiárias nas turmas e projetos ativos.",
+      "owner": "recepcao",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": true,
+          "effectiveAt": "2024-01-15",
+          "schemaFile": "form.inscricao_projeto.v1.json",
+          "notes": "Compatível com coleta de dados de presença e consentimentos."
+        }
+      ]
+    },
+    {
+      "type": "declaracao_recibo",
+      "title": "Declaração de Recibo",
+      "category": "financeiro",
+      "description": "Recibo oficial para entregas de benefícios, kits ou auxílios financeiros.",
+      "owner": "financeiro",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": false,
+          "effectiveAt": "2024-05-20",
+          "schemaFile": "form.declaracao_recibo.v1.json",
+          "notes": "Contempla campos para hash de verificação e anexos comprobatórios."
+        }
+      ]
+    },
+    {
+      "type": "consentimentos",
+      "title": "Registro de Consentimentos",
+      "category": "lgpd",
+      "description": "Coleta dos consentimentos de uso de imagem e dados pessoais conforme LGPD.",
+      "owner": "juridico",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": true,
+          "effectiveAt": "2024-01-10",
+          "schemaFile": "form.consentimentos.v1.json",
+          "notes": "Prevê registro de canal, vigência e evidências de aceite."
+        }
+      ]
+    },
+    {
+      "type": "roda_da_vida",
+      "title": "Roda da Vida",
+      "category": "diagnostico",
+      "description": "Ferramenta visual para diagnóstico de dimensões de bem-estar e autonomia.",
+      "owner": "psicologia",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": false,
+          "effectiveAt": "2024-04-05",
+          "schemaFile": "form.roda_da_vida.v1.json",
+          "notes": "Escala de 0 a 10 para 12 dimensões com comentários qualitativos."
+        }
+      ]
+    },
+    {
+      "type": "visao_holistica",
+      "title": "Visão Holística Familiar",
+      "category": "diagnostico",
+      "description": "Mapa das condições do núcleo familiar, rede de apoio e indicadores de risco.",
+      "owner": "servico_social",
+      "versions": [
+        {
+          "version": "v1",
+          "status": "active",
+          "mandatory": true,
+          "effectiveAt": "2024-04-20",
+          "schemaFile": "form.visao_holistica.v1.json",
+          "notes": "Inclui composição familiar, renda e necessidades prioritárias."
+        }
+      ]
+    }
+  ]
+}

--- a/artifacts/sql/0001_initial.sql
+++ b/artifacts/sql/0001_initial.sql
@@ -96,6 +96,7 @@ create table if not exists form_submissions (
   payload jsonb not null,
   signed_by text[],
   signed_at timestamptz[],
+  signature_evidence jsonb,
   attachments jsonb,
   created_by uuid references users(id),
   created_at timestamptz default now(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,15 @@
         "@fastify/helmet": "^13.0.1",
         "@fastify/jwt": "^10.0.0",
         "@fastify/multipart": "^9.2.1",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "bcryptjs": "^3.0.2",
         "dotenv": "^17.2.2",
         "fastify": "^5.6.1",
         "ioredis": "^5.4.1",
         "pg": "^8.16.3",
         "pino": "^9.11.0",
+        "qrcode": "^1.5.4",
         "uuid": "^13.0.0",
         "zod": "^4.1.11"
       },
@@ -1218,6 +1221,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -1334,6 +1361,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1361,6 +1397,17 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -1369,6 +1416,24 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -1401,6 +1466,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-eql": {
@@ -1449,6 +1523,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -1491,6 +1571,12 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1791,6 +1877,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1822,6 +1921,15 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -1982,6 +2090,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -2087,6 +2204,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -2253,6 +2382,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -2488,6 +2662,15 @@
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2572,6 +2755,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -2639,6 +2839,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2647,6 +2856,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2807,6 +3022,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -2897,6 +3118,32 @@
         "fastq": "^1.3.0",
         "fastseries": "^1.7.0",
         "reusify": "^1.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-literal": {
@@ -3216,6 +3463,12 @@
         }
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3233,6 +3486,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3242,12 +3509,53 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/zod": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,17 @@
     "@fastify/helmet": "^13.0.1",
     "@fastify/jwt": "^10.0.0",
     "@fastify/multipart": "^9.2.1",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "bcryptjs": "^3.0.2",
     "dotenv": "^17.2.2",
     "fastify": "^5.6.1",
+    "ioredis": "^5.4.1",
     "pg": "^8.16.3",
     "pino": "^9.11.0",
+    "qrcode": "^1.5.4",
     "uuid": "^13.0.0",
-    "zod": "^4.1.11",
-    "ioredis": "^5.4.1"
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -13,6 +13,7 @@ const envSchema = z.object({
   REDIS_URL: z.string().url().optional(),
   CACHE_TTL_SECONDS: z.string().regex(/^[0-9]+$/).default('300'),
   UPLOADS_DIR: z.string().default('tmp/uploads'),
+  PUBLIC_APP_BASE_URL: z.string().url().default('https://imm.local'),
   NOTIFICATIONS_EMAIL_FROM: z.string().email().default('alerts@imm.local'),
   NOTIFICATIONS_EMAIL_RECIPIENTS: z.string().optional(),
   NOTIFICATIONS_WHATSAPP_NUMBERS: z.string().optional(),

--- a/src/modules/forms/registry.ts
+++ b/src/modules/forms/registry.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+
+export const formVersionStatusSchema = z.enum(['active', 'inactive', 'deprecated']);
+
+const formVersionSchema = z.object({
+  version: z.string().min(1),
+  status: formVersionStatusSchema.default('active'),
+  mandatory: z.boolean().default(false),
+  effectiveAt: z.string().optional(),
+  schemaFile: z.string().min(1),
+  notes: z.string().optional(),
+});
+
+const formRegistryEntrySchema = z.object({
+  type: z.string().min(1),
+  title: z.string().min(1),
+  category: z.string().min(1),
+  description: z.string().min(1),
+  owner: z.string().min(1),
+  versions: z.array(formVersionSchema).min(1),
+});
+
+const formRegistrySchema = z.object({
+  registryVersion: z.string().min(1),
+  updatedAt: z.string().optional(),
+  forms: z.array(formRegistryEntrySchema),
+});
+
+export type FormVersionMetadata = z.infer<typeof formVersionSchema>;
+export type FormRegistryEntry = z.infer<typeof formRegistryEntrySchema>;
+export type FormRegistry = z.infer<typeof formRegistrySchema>;
+
+let cachedRegistry: FormRegistry | null = null;
+
+function resolveRegistryPath(): string {
+  return path.resolve('artifacts/json_schemas/registry.json');
+}
+
+export async function loadFormRegistry(): Promise<FormRegistry> {
+  if (cachedRegistry) {
+    return cachedRegistry;
+  }
+
+  const registryPath = resolveRegistryPath();
+  const raw = await fs.readFile(registryPath, 'utf8');
+  const parsed = formRegistrySchema.parse(JSON.parse(raw));
+  cachedRegistry = parsed;
+  return parsed;
+}
+
+export async function getRegistryEntry(formType: string): Promise<FormRegistryEntry | null> {
+  const registry = await loadFormRegistry();
+  return registry.forms.find((entry) => entry.type === formType) ?? null;
+}
+
+export async function getRegistryVersion(
+  formType: string,
+  version: string,
+): Promise<FormVersionMetadata | null> {
+  const entry = await getRegistryEntry(formType);
+  if (!entry) {
+    return null;
+  }
+
+  return entry.versions.find((item) => item.version === version) ?? null;
+}
+
+export async function loadSchemaFromRegistry(formType: string, version: string): Promise<Record<string, unknown> | null> {
+  const versionMeta = await getRegistryVersion(formType, version);
+  if (!versionMeta) {
+    return null;
+  }
+
+  const schemaPath = path.resolve('artifacts/json_schemas', versionMeta.schemaFile);
+  const raw = await fs.readFile(schemaPath, 'utf8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+export async function listMandatoryForms(): Promise<Array<{ type: string; version: string }>> {
+  const registry = await loadFormRegistry();
+  const mandatory: Array<{ type: string; version: string }> = [];
+
+  for (const form of registry.forms) {
+    for (const version of form.versions) {
+      if (version.mandatory && version.status === 'active') {
+        mandatory.push({ type: form.type, version: version.version });
+      }
+    }
+  }
+
+  return mandatory;
+}
+
+export function clearRegistryCache() {
+  cachedRegistry = null;
+}

--- a/src/modules/forms/schema-validator.ts
+++ b/src/modules/forms/schema-validator.ts
@@ -1,0 +1,48 @@
+import type { ErrorObject, ValidateFunction } from 'ajv';
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import { AppError } from '../../shared/errors';
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+
+const validatorCache = new Map<string, ValidateFunction>();
+
+function getValidator(schema: Record<string, unknown>): ValidateFunction {
+  const cacheKey = JSON.stringify(schema);
+  const cached = validatorCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const validator = ajv.compile(schema);
+  validatorCache.set(cacheKey, validator);
+  return validator;
+}
+
+function formatErrors(errors: ErrorObject[] | null | undefined) {
+  if (!errors || errors.length === 0) {
+    return undefined;
+  }
+
+  return errors.map((error) => ({
+    path: error.instancePath || error.schemaPath,
+    message: error.message ?? 'Valor inválido',
+    keyword: error.keyword,
+    params: error.params,
+  }));
+}
+
+export function validateFormPayloadOrThrow(schema: Record<string, unknown>, payload: unknown) {
+  const validator = getValidator(schema);
+  const valid = validator(payload);
+  if (!valid) {
+    throw new AppError('Form payload does not match schema', 400, {
+      validation: formatErrors(validator.errors),
+    });
+  }
+}
+
+export function clearSchemaValidatorCache() {
+  validatorCache.clear();
+}

--- a/src/modules/forms/schemas.ts
+++ b/src/modules/forms/schemas.ts
@@ -31,6 +31,16 @@ export const formAttachmentSchema = z.object({
   sizeBytes: z.number().int().nonnegative().optional(),
 }).catchall(z.unknown());
 
+const signatureEvidenceSchema = z.object({
+  signer: z.string().min(1),
+  capturedAt: isoDateTime.nullable().optional(),
+  method: z.string().min(1).nullable().optional(),
+  ipAddress: z.string().min(3).nullable().optional(),
+  userAgent: z.string().min(1).nullable().optional(),
+  payloadHash: z.string().regex(/^[a-f0-9]{64}$/i).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
+});
+
 const baseSubmissionSchema = z.object({
   formType: z.string().min(1),
   schemaVersion: z.string().min(1).optional(),
@@ -38,6 +48,7 @@ const baseSubmissionSchema = z.object({
   signedBy: z.array(z.string().min(1)).optional(),
   signedAt: z.array(isoDateTime).optional(),
   attachments: z.array(formAttachmentSchema).optional(),
+  signatureEvidence: z.array(signatureEvidenceSchema).optional(),
 });
 
 export const createFormSubmissionBodySchema = baseSubmissionSchema.superRefine((data, ctx) => {
@@ -48,6 +59,22 @@ export const createFormSubmissionBodySchema = baseSubmissionSchema.superRefine((
       path: ['signedAt'],
     });
   }
+
+  if (data.signatureEvidence && data.signedBy && data.signatureEvidence.length !== data.signedBy.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'signatureEvidence must have the same number of entries as signedBy',
+      path: ['signatureEvidence'],
+    });
+  }
+
+  if (data.signatureEvidence && data.signedAt && data.signatureEvidence.length !== data.signedAt.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'signatureEvidence must have the same number of entries as signedAt',
+      path: ['signatureEvidence'],
+    });
+  }
 });
 
 export const updateFormSubmissionBodySchema = z.object({
@@ -55,12 +82,29 @@ export const updateFormSubmissionBodySchema = z.object({
   signedBy: z.array(z.string().min(1)).nullable().optional(),
   signedAt: z.array(isoDateTime).nullable().optional(),
   attachments: z.array(formAttachmentSchema).nullable().optional(),
+  signatureEvidence: z.array(signatureEvidenceSchema).nullable().optional(),
 }).superRefine((data, ctx) => {
   if (data.signedAt && data.signedBy && data.signedAt.length !== data.signedBy.length) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'signedAt must have the same number of entries as signedBy',
       path: ['signedAt'],
+    });
+  }
+
+  if (data.signatureEvidence && data.signedBy && data.signatureEvidence.length !== data.signedBy.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'signatureEvidence must have the same number of entries as signedBy',
+      path: ['signatureEvidence'],
+    });
+  }
+
+  if (data.signatureEvidence && data.signedAt && data.signatureEvidence.length !== data.signedAt.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'signatureEvidence must have the same number of entries as signedAt',
+      path: ['signatureEvidence'],
     });
   }
 });

--- a/src/modules/forms/types.ts
+++ b/src/modules/forms/types.ts
@@ -16,6 +16,16 @@ export type FormAttachment = {
   [key: string]: unknown;
 };
 
+export type SignatureEvidenceEntry = {
+  signer: string;
+  capturedAt?: string | null;
+  method?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  payloadHash?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
 export type FormSubmissionSummary = {
   id: string;
   beneficiaryId: string;
@@ -32,6 +42,7 @@ export type FormSubmissionRecord = FormSubmissionSummary & {
   signedBy: string[];
   signedAt: string[];
   attachments: FormAttachment[];
+  signatureEvidence: SignatureEvidenceEntry[];
   template?: FormTemplateRecord | null;
 };
 
@@ -68,6 +79,7 @@ export type CreateSubmissionInput = {
   signedBy?: string[];
   signedAt?: string[];
   attachments?: FormAttachment[];
+  signatureEvidence?: SignatureEvidenceEntry[];
   createdBy?: string | null;
 };
 
@@ -80,4 +92,5 @@ export type UpdateSubmissionParams = {
   signedBy?: string[] | null;
   signedAt?: string[] | null;
   attachments?: FormAttachment[] | null;
+  signatureEvidence?: SignatureEvidenceEntry[] | null;
 };

--- a/tests/forms.service.test.ts
+++ b/tests/forms.service.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../src/shared/errors';
+import { createSubmission } from '../src/modules/forms/service';
+
+const {
+  createFormSubmissionMock,
+  getTemplateByTypeAndVersionMock,
+  getLatestActiveTemplateMock,
+} = vi.hoisted(() => ({
+  createFormSubmissionMock: vi.fn(),
+  getTemplateByTypeAndVersionMock: vi.fn(),
+  getLatestActiveTemplateMock: vi.fn(),
+}));
+
+vi.mock('../src/modules/forms/repository', () => ({
+  createFormSubmission: createFormSubmissionMock,
+  createFormTemplate: vi.fn(),
+  getFormSubmissionById: vi.fn(),
+  getLatestActiveTemplate: getLatestActiveTemplateMock,
+  getTemplateById: vi.fn(),
+  getTemplateByTypeAndVersion: getTemplateByTypeAndVersionMock,
+  listFormTemplates: vi.fn(),
+  listSubmissionsByBeneficiary: vi.fn(),
+  updateFormSubmission: vi.fn(),
+  updateFormTemplate: vi.fn(),
+}));
+
+vi.mock('../src/modules/beneficiaries/repository', () => ({
+  getBeneficiaryById: vi.fn(),
+}));
+
+describe('form submission service', () => {
+  const baseTemplate = {
+    id: 'template-1',
+    formType: 'anamnese_social',
+    schemaVersion: 'v1',
+    schema: {
+      type: 'object',
+      required: ['nome'],
+      properties: {
+        nome: { type: 'string' },
+        idade: { type: 'number' },
+      },
+    },
+    status: 'active',
+    publishedAt: '2024-01-01T00:00:00.000Z',
+  } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTemplateByTypeAndVersionMock.mockResolvedValue(baseTemplate);
+    getLatestActiveTemplateMock.mockResolvedValue(baseTemplate);
+  });
+
+  it('valida payload conforme schema e rejeita dados inválidos', async () => {
+    await expect(createSubmission({
+      beneficiaryId: 'benef-1',
+      formType: 'anamnese_social',
+      schemaVersion: 'v1',
+      payload: {},
+    })).rejects.toBeInstanceOf(AppError);
+
+    expect(createFormSubmissionMock).not.toHaveBeenCalled();
+  });
+
+  it('envia evidências de assinatura para o repositório ao criar submissão', async () => {
+    const submissionRecord = {
+      id: 'subm-1',
+      beneficiaryId: 'benef-1',
+      beneficiaryName: 'Maria',
+      formType: 'anamnese_social',
+      schemaVersion: 'v1',
+      payload: { nome: 'Maria' },
+      signedBy: ['Maria'],
+      signedAt: ['2024-08-01T10:00:00.000Z'],
+      attachments: [],
+      signatureEvidence: [],
+      createdAt: '2024-08-01T10:00:00.000Z',
+      updatedAt: '2024-08-01T10:00:00.000Z',
+      template: baseTemplate,
+    };
+
+    createFormSubmissionMock.mockResolvedValue(submissionRecord);
+
+    const signatureEvidence = [
+      {
+        signer: 'Maria',
+        capturedAt: '2024-08-01T10:00:00.000Z',
+        method: 'assinatura_biometrica',
+        ipAddress: '10.0.0.42',
+        userAgent: 'MoveForms/1.0 (Android 13)',
+        payloadHash: 'f'.repeat(64),
+      },
+    ];
+
+    await createSubmission({
+      beneficiaryId: 'benef-1',
+      formType: 'anamnese_social',
+      schemaVersion: 'v1',
+      payload: { nome: 'Maria' },
+      signedBy: ['Maria'],
+      signedAt: ['2024-08-01T10:00:00.000Z'],
+      signatureEvidence,
+    });
+
+    expect(createFormSubmissionMock).toHaveBeenCalledWith(expect.objectContaining({
+      signatureEvidence,
+    }));
+  });
+});

--- a/tools/pdf-renderer/render_pdf.js
+++ b/tools/pdf-renderer/render_pdf.js
@@ -86,6 +86,10 @@ function buildHtmlDocument(body) {
     table { width: 100%; border-collapse: collapse; margin-top: 16px; font-size: 12px; }
     th, td { border: 1px solid #e2e8f0; padding: 8px 12px; text-align: left; }
     th { background: #f1f5f9; font-weight: 600; }
+    .imm-verification { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px 16px; margin-top: 16px; font-size: 12px; }
+    .imm-qr-wrapper { margin-top: 12px; }
+    .imm-qr { width: 120px; height: 120px; }
+    .imm-signature-meta { margin: 8px 0 0 0; padding-left: 18px; list-style: disc; color: #475569; font-size: 11px; }
   </style>
 </head>
 <body>

--- a/tools/pdf-renderer/templates/form_submission.hbs
+++ b/tools/pdf-renderer/templates/form_submission.hbs
@@ -15,6 +15,15 @@
   {{#if generatedAt}}
   <p><strong>Documento gerado em:</strong> {{generatedAt}}</p>
   {{/if}}
+  <div class="imm-verification">
+    <p><strong>Hash de verificação:</strong> {{verification.hash}}</p>
+    <p><strong>Verificação pública:</strong> {{verification.url}}</p>
+    {{#if verification.qrCodeDataUrl}}
+    <div class="imm-qr-wrapper">
+      <img src="{{verification.qrCodeDataUrl}}" alt="QR code para verificação" class="imm-qr" />
+    </div>
+    {{/if}}
+  </div>
 </section>
 
 {{#each sections}}
@@ -40,6 +49,8 @@
       <tr>
         <th>Responsável</th>
         <th>Data</th>
+        <th>Método</th>
+        <th>IP</th>
       </tr>
     </thead>
     <tbody>
@@ -47,7 +58,20 @@
       <tr>
         <td>{{name}}</td>
         <td>{{#if signedAt}}{{signedAt}}{{else}}Não informado{{/if}}</td>
+        <td>{{#if method}}{{method}}{{else}}Não informado{{/if}}</td>
+        <td>{{#if ipAddress}}{{ipAddress}}{{else}}-{{/if}}</td>
       </tr>
+      {{#if metadata.length}}
+      <tr>
+        <td colspan="4">
+          <ul class="imm-signature-meta">
+            {{#each metadata}}
+            <li>{{this}}</li>
+            {{/each}}
+          </ul>
+        </td>
+      </tr>
+      {{/if}}
       {{/each}}
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- add JSON schema registry loader, cached Ajv validator, and versioned template management
- persist signature evidence data, expose registry API, and enrich PDF exports with verification hash/QR
- seed realistic form payloads, update SQL/env configuration, and include targeted service tests

## Testing
- npx vitest run tests/forms.service.test.ts tests/integration/forms.pdf.test.ts
- npm test *(stopped after ~100s while analytics suite queued; other suites had already passed)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eb124b3083248f9e73a88f17de20