### PR TITLE
Finalize communication and action plan interfaces

### DIFF
--- a/apps/dashboard/components/MessageCenter.tsx
+++ b/apps/dashboard/components/MessageCenter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 
 interface Participant {
@@ -149,11 +149,57 @@ function PresenceIndicator({ status }: { status: Participant['status'] }) {
 
 export function MessageCenter() {
   const [selectedThreadId, setSelectedThreadId] = useState(THREADS[0].id);
+  const [channelFilter, setChannelFilter] = useState<'Todos' | MessageThread['channel']>('Todos');
+
+  const channels = useMemo(
+    () => Array.from(new Set(THREADS.map((thread) => thread.channel))) as MessageThread['channel'][],
+    [],
+  );
+
+  const filteredThreads = useMemo(() => {
+    if (channelFilter === 'Todos') {
+      return THREADS;
+    }
+
+    return THREADS.filter((thread) => thread.channel === channelFilter);
+  }, [channelFilter]);
+
+  useEffect(() => {
+    if (filteredThreads.length === 0) {
+      return;
+    }
+
+    const isSelectedVisible = filteredThreads.some((thread) => thread.id === selectedThreadId);
+    if (!isSelectedVisible) {
+      setSelectedThreadId(filteredThreads[0].id);
+    }
+  }, [filteredThreads, selectedThreadId]);
 
   const selectedThread = useMemo(
-    () => THREADS.find((thread) => thread.id === selectedThreadId) ?? THREADS[0],
-    [selectedThreadId],
+    () => filteredThreads.find((thread) => thread.id === selectedThreadId) ?? filteredThreads[0] ?? THREADS[0],
+    [filteredThreads, selectedThreadId],
   );
+
+  const threadAttachments = useMemo(
+    () => selectedThread?.messages.flatMap((message) => message.attachments ?? []) ?? [],
+    [selectedThread],
+  );
+
+  const deliveryStats = useMemo(() => {
+    return selectedThread?.messages.reduce(
+      (acc, message) => {
+        if (message.delivery) {
+          acc[message.delivery] += 1;
+        }
+        return acc;
+      },
+      { enviado: 0, entregue: 0, lido: 0 },
+    );
+  }, [selectedThread]);
+
+  if (!selectedThread) {
+    return null;
+  }
 
   return (
     <section className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)]">
@@ -166,8 +212,38 @@ export function MessageCenter() {
           <span className="rounded-full bg-emerald-400/20 px-3 py-1 text-xs font-medium text-emerald-300">Sincronizado</span>
         </header>
 
+        <div className="mb-2 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setChannelFilter('Todos')}
+            className={clsx(
+              'rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide transition',
+              channelFilter === 'Todos'
+                ? 'border-white/30 bg-white/10 text-white shadow-inner'
+                : 'border-white/10 bg-white/0 text-white/70 hover:border-white/20 hover:bg-white/10 hover:text-white',
+            )}
+          >
+            Todos os canais
+          </button>
+          {channels.map((channel) => (
+            <button
+              key={channel}
+              type="button"
+              onClick={() => setChannelFilter(channel)}
+              className={clsx(
+                'rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide transition',
+                channelFilter === channel
+                  ? 'border-white/30 bg-white/10 text-white shadow-inner'
+                  : 'border-white/10 bg-white/0 text-white/70 hover:border-white/20 hover:bg-white/10 hover:text-white',
+              )}
+            >
+              {channel}
+            </button>
+          ))}
+        </div>
+
         <div className="flex flex-col gap-2 overflow-y-auto pr-1">
-          {THREADS.map((thread) => (
+          {filteredThreads.map((thread) => (
             <button
               key={thread.id}
               type="button"
@@ -221,85 +297,177 @@ export function MessageCenter() {
           </div>
         </header>
 
-        <div className="flex flex-col gap-6 overflow-y-auto">
-          {selectedThread.messages.map((message) => {
-            const sender = selectedThread.participants.find((participant) => participant.id === message.senderId);
-            return (
-              <div
-                key={message.id}
-                className="flex flex-col gap-2 rounded-2xl border border-white/5 bg-white/5 p-4 shadow-inner shadow-black/10"
-              >
-                <div className="flex flex-wrap items-center gap-3">
-                  <div className="flex items-center gap-2">
-                    <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white">
-                      {sender?.avatar}
-                    </span>
-                    <div>
-                      <p className="text-sm font-semibold text-white">{sender?.name}</p>
-                      <p className="text-[11px] uppercase tracking-wide text-white/50">{sender?.role}</p>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <div className="flex flex-col gap-6 overflow-y-auto">
+            {selectedThread.messages.map((message) => {
+              const sender = selectedThread.participants.find((participant) => participant.id === message.senderId);
+              return (
+                <div
+                  key={message.id}
+                  className="flex flex-col gap-2 rounded-2xl border border-white/5 bg-white/5 p-4 shadow-inner shadow-black/10"
+                >
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="flex items-center gap-2">
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white">
+                        {sender?.avatar}
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-white">{sender?.name}</p>
+                        <p className="text-[11px] uppercase tracking-wide text-white/50">{sender?.role}</p>
+                      </div>
                     </div>
+                    <span className="text-xs text-white/60">{message.timestamp}</span>
+                    {message.delivery && (
+                      <span className="flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-[10px] uppercase tracking-wide text-white/70">
+                        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                        {message.delivery}
+                      </span>
+                    )}
                   </div>
-                  <span className="text-xs text-white/60">{message.timestamp}</span>
-                  {message.delivery && (
-                    <span className="flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-[10px] uppercase tracking-wide text-white/70">
-                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-                      {message.delivery}
-                    </span>
+
+                  <p className="text-sm text-white/80">{message.content}</p>
+
+                  {message.attachments && message.attachments.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {message.attachments.map((attachment) => (
+                        <div
+                          key={attachment.id}
+                          className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80"
+                        >
+                          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-imm-indigo/20 text-imm-indigo-100">
+                            {attachment.type === 'document' && '📄'}
+                            {attachment.type === 'image' && '🖼️'}
+                            {attachment.type === 'spreadsheet' && '📊'}
+                          </span>
+                          <div className="flex flex-col">
+                            <span className="font-medium text-white">{attachment.name}</span>
+                            <span className="text-[11px] uppercase tracking-wide text-white/50">{attachment.size}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
+              );
+            })}
 
-                <p className="text-sm text-white/80">{message.content}</p>
-
-                {message.attachments && message.attachments.length > 0 && (
-                  <div className="flex flex-wrap gap-2">
-                    {message.attachments.map((attachment) => (
-                      <div
-                        key={attachment.id}
-                        className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80"
-                      >
-                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-imm-indigo/20 text-imm-indigo-100">
-                          {attachment.type === 'document' && '📄'}
-                          {attachment.type === 'image' && '🖼️'}
-                          {attachment.type === 'spreadsheet' && '📊'}
-                        </span>
-                        <div className="flex flex-col">
-                          <span className="font-medium text-white">{attachment.name}</span>
-                          <span className="text-[11px] uppercase tracking-wide text-white/50">{attachment.size}</span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
+            <footer className="rounded-2xl border border-white/10 bg-white/0 p-4">
+              <span className="mb-2 block text-xs uppercase tracking-wide text-white/50">Enviar atualização</span>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <textarea
+                  rows={3}
+                  placeholder="Escreva uma mensagem para a equipe..."
+                  className="min-h-[90px] flex-1 rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                />
+                <div className="flex flex-col justify-between gap-2">
+                  <button
+                    type="button"
+                    className="flex items-center justify-center gap-2 rounded-2xl border border-white/20 bg-white/0 px-4 py-2 text-sm font-medium text-white transition hover:border-white/40 hover:bg-white/10"
+                  >
+                    <span>📎</span>
+                    Anexar
+                  </button>
+                  <button
+                    type="button"
+                    className="flex items-center justify-center gap-2 rounded-2xl bg-imm-emerald/80 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-imm-emerald/30 transition hover:bg-imm-emerald"
+                  >
+                    Enviar atualização
+                  </button>
+                </div>
               </div>
-            );
-          })}
-        </div>
-
-        <footer className="rounded-2xl border border-white/10 bg-white/0 p-4">
-          <span className="mb-2 block text-xs uppercase tracking-wide text-white/50">Enviar atualização</span>
-          <div className="flex flex-col gap-3 sm:flex-row">
-            <textarea
-              rows={3}
-              placeholder="Escreva uma mensagem para a equipe..."
-              className="min-h-[90px] flex-1 rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
-            />
-            <div className="flex flex-col justify-between gap-2">
-              <button
-                type="button"
-                className="flex items-center justify-center gap-2 rounded-2xl border border-white/20 bg-white/0 px-4 py-2 text-sm font-medium text-white transition hover:border-white/40 hover:bg-white/10"
-              >
-                <span>📎</span>
-                Anexar
-              </button>
-              <button
-                type="button"
-                className="flex items-center justify-center gap-2 rounded-2xl bg-imm-emerald/80 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-imm-emerald/30 transition hover:bg-imm-emerald"
-              >
-                Enviar atualização
-              </button>
-            </div>
+            </footer>
           </div>
-        </footer>
+
+          <aside className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-white/10 p-4">
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">Participantes</h3>
+              <div className="flex flex-col gap-3">
+                {selectedThread.participants.map((participant) => (
+                  <div key={participant.id} className="flex items-center justify-between gap-3 rounded-2xl bg-white/5 px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm font-semibold text-white">
+                        {participant.avatar}
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-white">{participant.name}</p>
+                        <p className="text-[11px] uppercase tracking-wide text-white/50">{participant.role}</p>
+                      </div>
+                    </div>
+                    <PresenceIndicator status={participant.status} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">Indicadores da thread</h3>
+              <div className="grid gap-2 text-xs text-white/70">
+                <span className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
+                  <span>Total de mensagens</span>
+                  <span className="text-sm font-semibold text-white">{selectedThread.messages.length}</span>
+                </span>
+                <span className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
+                  <span>Mensagens com anexos</span>
+                  <span className="text-sm font-semibold text-white">
+                    {selectedThread.messages.filter((message) => (message.attachments ?? []).length > 0).length}
+                  </span>
+                </span>
+                <div className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
+                  <span>Entregas</span>
+                  <div className="grid gap-1 text-[11px] uppercase tracking-wide text-white/60">
+                    <span className="flex items-center justify-between">
+                      <span>Enviadas</span>
+                      <span>{deliveryStats?.enviado ?? 0}</span>
+                    </span>
+                    <span className="flex items-center justify-between">
+                      <span>Entregues</span>
+                      <span>{deliveryStats?.entregue ?? 0}</span>
+                    </span>
+                    <span className="flex items-center justify-between">
+                      <span>Lidas</span>
+                      <span>{deliveryStats?.lido ?? 0}</span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">Anexos recentes</h3>
+              <div className="flex flex-col gap-2 text-xs text-white/80">
+                {threadAttachments.length === 0 && (
+                  <span className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-white/60">
+                    Nenhum anexo enviado nesta thread ainda.
+                  </span>
+                )}
+                {threadAttachments.map((attachment) => (
+                  <div
+                    key={`${attachment.id}-${attachment.name}`}
+                    className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg">
+                        {attachment.type === 'document' && '📄'}
+                        {attachment.type === 'image' && '🖼️'}
+                        {attachment.type === 'spreadsheet' && '📊'}
+                      </span>
+                      <div className="flex flex-col">
+                        <span className="font-medium text-white">{attachment.name}</span>
+                        <span className="text-[11px] uppercase tracking-wide text-white/50">{attachment.size}</span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className="rounded-full border border-white/10 bg-white/0 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-white/70 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
+                    >
+                      Baixar
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
       </article>
     </section>
   );


### PR DESCRIPTION
## Summary
- add channel filters, delivery metrics, and attachment sidebar to the internal messaging threads
- enable segmented audience filters and empty states in the institutional feed with confirmation tracking
- enrich the action plan panel with status filters, progress visualization, and reminder summaries

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d417173efc8324b9ea0d37ba3c5db1