### PR TITLE
feat(dashboard): add login flow and session management

### DIFF
--- a/apps/dashboard/app/(auth)/login/page.tsx
+++ b/apps/dashboard/app/(auth)/login/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { login, mapLoginResponseToSession, type LoginMfaResponse, type LoginSuccessResponse } from '../../../lib/auth';
+import { saveSession } from '../../../lib/session';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pendingChallenge, setPendingChallenge] = useState<LoginMfaResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setPendingChallenge(null);
+
+    if (!email || !password) {
+      setError('Informe e-mail e senha para continuar.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = await login(email, password);
+      if ('mfaRequired' in result && result.mfaRequired) {
+        setPendingChallenge(result);
+        return;
+      }
+
+      const session = mapLoginResponseToSession(result as LoginSuccessResponse);
+      saveSession(session);
+      router.replace('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro inesperado ao entrar.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none fixed inset-0 overflow-hidden">
+        <div className="absolute -top-24 left-1/3 h-96 w-96 rounded-full bg-emerald-500/10 blur-3xl" />
+        <div className="absolute top-1/3 -right-32 h-80 w-80 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-64 w-64 rounded-full bg-cyan-400/15 blur-3xl" />
+      </div>
+
+      <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-12">
+        <div className="w-full max-w-md space-y-8 rounded-3xl border border-white/10 bg-white/5 p-10 backdrop-blur-3xl shadow-2xl shadow-black/30">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-semibold tracking-tight text-white">Acessar painel IMM</h1>
+            <p className="text-sm text-slate-200/70">Use suas credenciais institucionais para visualizar o dashboard.</p>
+          </div>
+
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div className="space-y-4">
+              <label className="block text-left text-sm font-medium text-slate-200" htmlFor="email">
+                E-mail institucional
+              </label>
+              <input
+                id="email"
+                type="email"
+                className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-emerald-400/70 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="nome@movemarias.org"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                disabled={isSubmitting}
+              />
+
+              <label className="block text-left text-sm font-medium text-slate-200" htmlFor="password">
+                Senha
+              </label>
+              <input
+                id="password"
+                type="password"
+                className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-emerald-400/70 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                placeholder="Digite sua senha"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="current-password"
+                disabled={isSubmitting}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                {error}
+              </div>
+            )}
+
+            {pendingChallenge && (
+              <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+                <p className="font-medium">Verificação adicional necessária</p>
+                <p className="mt-1 text-amber-100/80">
+                  Um desafio de múltiplos fatores foi iniciado. Conclua a verificação via {pendingChallenge.methods.join(' ou ')}
+                  para continuar.
+                </p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              className="w-full rounded-2xl bg-emerald-500/90 px-4 py-3 text-base font-semibold text-emerald-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Entrando...' : 'Entrar'}
+            </button>
+          </form>
+
+          <p className="text-center text-xs text-slate-400">
+            Dificuldades para entrar? Procure a coordenação IMM para redefinir sua senha ou habilitar MFA.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -25,6 +25,10 @@ export default function DashboardPage() {
   const { filters, update, reset } = useDashboardFilters();
   const { overview, isLoading, error } = useAnalyticsOverview(filters);
 
+  if (session === undefined) {
+    return <LoadingState message="Verificando sessão..." />;
+  }
+
   if (!session) {
     return <LoadingState message="Verificando sessão..." />;
   }

--- a/apps/dashboard/hooks/useRequirePermission.ts
+++ b/apps/dashboard/hooks/useRequirePermission.ts
@@ -10,7 +10,12 @@ export function useRequirePermission(required: string | string[]) {
   const requirements = Array.isArray(required) ? required : [required];
 
   useEffect(() => {
+    if (session === undefined) {
+      return;
+    }
+
     if (!session) {
+      router.replace('/login');
       return;
     }
 

--- a/apps/dashboard/lib/api.ts
+++ b/apps/dashboard/lib/api.ts
@@ -1,6 +1,6 @@
 'use client';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3333';
+export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3333';
 
 export async function fetchJson(path: string, params: Record<string, unknown> = {}, token?: string | null) {
   const search = new URLSearchParams();

--- a/apps/dashboard/lib/auth.ts
+++ b/apps/dashboard/lib/auth.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { API_URL } from './api';
+import type { Session } from './session';
+
+export type LoginSuccessResponse = {
+  token: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    roles: { slug: string; projectId?: string | null }[];
+    permissions: { key: string }[];
+  };
+  projectScopes?: string[];
+};
+
+export type LoginMfaResponse = {
+  mfaRequired: true;
+  challengeId: string;
+  methods: string[];
+  expiresAt: string;
+  webauthnOptions?: unknown;
+};
+
+export type LoginResponse = LoginSuccessResponse | LoginMfaResponse;
+
+export function mapLoginResponseToSession(response: LoginSuccessResponse): Session {
+  const permissions = response.user.permissions.map((permission) => permission.key);
+  const roles = response.user.roles.map((role) => role.slug);
+
+  return {
+    token: response.token,
+    refreshToken: response.refreshToken,
+    refreshTokenExpiresAt: response.refreshTokenExpiresAt ?? null,
+    permissions,
+    roles,
+    projectScopes: response.projectScopes ?? [],
+    user: {
+      id: response.user.id,
+      name: response.user.name,
+      email: response.user.email,
+    },
+  };
+}
+
+export async function login(email: string, password: string): Promise<LoginResponse> {
+  const response = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (response.status === 202) {
+    const body = (await response.json()) as LoginMfaResponse;
+    return body;
+  }
+
+  if (!response.ok) {
+    let message = 'Não foi possível entrar. Verifique suas credenciais.';
+    try {
+      const body = (await response.json()) as { message?: string };
+      if (body?.message) {
+        message = body.message;
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const body = (await response.json()) as LoginSuccessResponse;
+  return body;
+}

--- a/apps/dashboard/lib/session.ts
+++ b/apps/dashboard/lib/session.ts
@@ -1,0 +1,80 @@
+'use client';
+
+export const SESSION_STORAGE_KEY = 'imm:session';
+export const SESSION_EVENT = 'imm:session-changed';
+
+export type SessionUser = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+export type Session = {
+  token: string;
+  refreshToken: string | null;
+  refreshTokenExpiresAt: string | null;
+  permissions: string[];
+  roles: string[];
+  projectScopes: string[];
+  user: SessionUser;
+};
+
+export type StoredSession = Session;
+
+function isValidSession(value: unknown): value is StoredSession {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const session = value as Partial<StoredSession>;
+  return (
+    typeof session.token === 'string' &&
+    Array.isArray(session.permissions) &&
+    Array.isArray(session.roles) &&
+    typeof session.user === 'object' &&
+    session.user !== null &&
+    typeof session.user.id === 'string' &&
+    typeof session.user.name === 'string' &&
+    typeof session.user.email === 'string'
+  );
+}
+
+export function loadSession(): StoredSession | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isValidSession(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('Failed to parse stored session', error);
+  }
+
+  return null;
+}
+
+export function saveSession(session: StoredSession) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+  window.dispatchEvent(new CustomEvent<StoredSession>(SESSION_EVENT, { detail: session }));
+}
+
+export function clearSession() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  window.dispatchEvent(new CustomEvent<StoredSession | null>(SESSION_EVENT, { detail: null }));
+}

--- a/apps/dashboard/tests/Dashboard.test.tsx
+++ b/apps/dashboard/tests/Dashboard.test.tsx
@@ -2,7 +2,15 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import DashboardPage from '../app/page';
 
-const mockSession = { token: 'token', permissions: ['analytics:read'], roles: ['admin'] };
+const mockSession = {
+  token: 'token',
+  refreshToken: 'refresh',
+  refreshTokenExpiresAt: '2024-01-01T00:00:00.000Z',
+  permissions: ['analytics:read'],
+  roles: ['admin'],
+  projectScopes: [],
+  user: { id: '1', name: 'Admin', email: 'admin@example.com' },
+};
 const overviewMock = {
   kpis: {
     beneficiarias_ativas: 42,

--- a/apps/dashboard/tests/Login.test.tsx
+++ b/apps/dashboard/tests/Login.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import LoginPage from '../app/(auth)/login/page';
+
+const replaceMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+const loginMock = vi.fn();
+const mapSessionMock = vi.fn();
+const saveSessionMock = vi.fn();
+
+vi.mock('../lib/auth', () => ({
+  login: (...args: unknown[]) => loginMock(...args),
+  mapLoginResponseToSession: (...args: unknown[]) => mapSessionMock(...args),
+}));
+
+vi.mock('../lib/session', () => ({
+  saveSession: (...args: unknown[]) => saveSessionMock(...args),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    loginMock.mockReset();
+    mapSessionMock.mockReset();
+    saveSessionMock.mockReset();
+    replaceMock.mockReset();
+  });
+
+  it('shows validation error when fields are empty', async () => {
+    render(<LoginPage />);
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Entrar' }).closest('form')!);
+
+    expect(await screen.findByText('Informe e-mail e senha para continuar.')).toBeInTheDocument();
+    expect(loginMock).not.toHaveBeenCalled();
+  });
+
+  it('renders MFA message when challenge is required', async () => {
+    loginMock.mockResolvedValue({
+      mfaRequired: true,
+      challengeId: 'challenge',
+      methods: ['totp', 'webauthn'],
+      expiresAt: new Date().toISOString(),
+    });
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText('E-mail institucional'), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText('Senha'), { target: { value: 'secret' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Entrar' }).closest('form')!);
+
+    expect(await screen.findByText('Verificação adicional necessária')).toBeInTheDocument();
+    expect(saveSessionMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('saves session and redirects on success', async () => {
+    loginMock.mockResolvedValue({ token: 'token' });
+    const session = { token: 'token', permissions: [], roles: [], projectScopes: [], user: { id: '1', name: 'Ana', email: 'ana@example.com' }, refreshToken: 'refresh', refreshTokenExpiresAt: '2024-01-01T00:00:00.000Z' };
+    mapSessionMock.mockReturnValue(session);
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText('E-mail institucional'), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText('Senha'), { target: { value: 'secret' } });
+    fireEvent.submit(screen.getByRole('button', { name: 'Entrar' }).closest('form')!);
+
+    await waitFor(() => {
+      expect(saveSessionMock).toHaveBeenCalledWith(session);
+    });
+    expect(replaceMock).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## Summary
- add client-side session utilities and update permission hooks to redirect unauthenticated visitors
- implement glassmorphism login screen that persists sessions and surfaces MFA challenges
- expose API url helper and extend vitest coverage for the dashboard authentication flow

## Testing
- npm test (apps/dashboard)


------
https://chatgpt.com/codex/tasks/task_e_68d537541b3883248df8209f398da504