### PR TITLE
Document frontend integration steps and add dashboard UI primitives

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,0 +1,3 @@
+# URL base da API Fastify utilizada pelo dashboard.
+# Ajuste para apontar ao ambiente correto (ex.: http://localhost:3333, https://staging.api.moveongs.org).
+NEXT_PUBLIC_API_URL=http://localhost:3333

--- a/apps/dashboard/app/(auth)/login/page.tsx
+++ b/apps/dashboard/app/(auth)/login/page.tsx
@@ -4,6 +4,10 @@ import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { login, mapLoginResponseToSession, type LoginMfaResponse, type LoginSuccessResponse } from '../../../lib/auth';
 import { saveSession } from '../../../lib/session';
+import { Card } from '../../../components/ui/card';
+import { Input } from '../../../components/ui/input';
+import { Button } from '../../../components/ui/button';
+import { Alert } from '../../../components/ui/alert';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -50,7 +54,7 @@ export default function LoginPage() {
       </div>
 
       <div className="relative z-10 flex min-h-screen items-center justify-center px-6 py-12">
-        <div className="w-full max-w-md space-y-8 rounded-3xl border border-white/10 bg-white/5 p-10 backdrop-blur-3xl shadow-2xl shadow-black/30">
+        <Card className="w-full max-w-md space-y-8" padding="lg">
           <div className="space-y-2 text-center">
             <h1 className="text-3xl font-semibold tracking-tight text-white">Acessar painel IMM</h1>
             <p className="text-sm text-slate-200/70">Use suas credenciais institucionais para visualizar o dashboard.</p>
@@ -58,13 +62,10 @@ export default function LoginPage() {
 
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="space-y-4">
-              <label className="block text-left text-sm font-medium text-slate-200" htmlFor="email">
-                E-mail institucional
-              </label>
-              <input
+              <Input
                 id="email"
                 type="email"
-                className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-emerald-400/70 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                label="E-mail institucional"
                 placeholder="nome@movemarias.org"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
@@ -72,13 +73,10 @@ export default function LoginPage() {
                 disabled={isSubmitting}
               />
 
-              <label className="block text-left text-sm font-medium text-slate-200" htmlFor="password">
-                Senha
-              </label>
-              <input
+              <Input
                 id="password"
                 type="password"
-                className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-emerald-400/70 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+                label="Senha"
                 placeholder="Digite sua senha"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
@@ -87,35 +85,24 @@ export default function LoginPage() {
               />
             </div>
 
-            {error && (
-              <div className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
-                {error}
-              </div>
-            )}
+            {error && <Alert variant="error">{error}</Alert>}
 
             {pendingChallenge && (
-              <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-                <p className="font-medium">Verificação adicional necessária</p>
-                <p className="mt-1 text-amber-100/80">
-                  Um desafio de múltiplos fatores foi iniciado. Conclua a verificação via {pendingChallenge.methods.join(' ou ')}
-                  para continuar.
-                </p>
-              </div>
+              <Alert variant="warning" title="Verificação adicional necessária">
+                Um desafio de múltiplos fatores foi iniciado. Conclua a verificação via {pendingChallenge.methods.join(' ou ')}
+                para continuar.
+              </Alert>
             )}
 
-            <button
-              type="submit"
-              className="w-full rounded-2xl bg-emerald-500/90 px-4 py-3 text-base font-semibold text-emerald-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:bg-emerald-500/60"
-              disabled={isSubmitting}
-            >
+            <Button type="submit" fullWidth disabled={isSubmitting}>
               {isSubmitting ? 'Entrando...' : 'Entrar'}
-            </button>
+            </Button>
           </form>
 
           <p className="text-center text-xs text-slate-400">
             Dificuldades para entrar? Procure a coordenação IMM para redefinir sua senha ou habilitar MFA.
           </p>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/apps/dashboard/components/ExportButtons.tsx
+++ b/apps/dashboard/components/ExportButtons.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { Filters } from '../types/analytics';
 import { downloadFile } from '../lib/api';
 import { useSession } from '../hooks/useSession';
+import { Button } from './ui/button';
 
 interface ExportButtonsProps {
   filters: Filters;
@@ -29,22 +30,25 @@ export function ExportButtons({ filters }: ExportButtonsProps) {
 
   return (
     <div className="flex flex-wrap gap-2">
-      <button
+      <Button
         type="button"
+        variant="secondary"
+        size="sm"
         onClick={() => handleExport('csv')}
         disabled={loading !== null}
-        className="rounded-2xl border border-white/10 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-white/40 disabled:opacity-60"
       >
         {loading === 'csv' ? 'Exportando CSV...' : 'Exportar CSV'}
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
+        variant="primary"
+        size="sm"
+        className="bg-imm-indigo/60 text-white shadow-indigo-500/30 hover:bg-imm-indigo/50 focus:ring-imm-indigo/40 disabled:bg-imm-indigo/40"
         onClick={() => handleExport('pdf')}
         disabled={loading !== null}
-        className="rounded-2xl border border-white/10 bg-imm-indigo/40 px-4 py-2 text-sm font-medium text-white transition hover:border-white/40 disabled:opacity-60"
       >
         {loading === 'pdf' ? 'Gerando PDF...' : 'Exportar PDF'}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/dashboard/components/ui/alert.tsx
+++ b/apps/dashboard/components/ui/alert.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import clsx from 'clsx';
+
+export type AlertVariant = 'info' | 'error' | 'warning';
+
+interface AlertProps {
+  children: React.ReactNode;
+  variant?: AlertVariant;
+  title?: string;
+}
+
+const variantStyles: Record<AlertVariant, string> = {
+  info: 'border-sky-400/30 bg-sky-500/10 text-sky-100',
+  error: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  warning: 'border-amber-400/40 bg-amber-500/10 text-amber-100',
+};
+
+export function Alert({ children, variant = 'info', title }: AlertProps) {
+  return (
+    <div className={clsx('rounded-2xl border px-4 py-3 text-sm', variantStyles[variant])}>
+      {title && <p className="font-semibold">{title}</p>}
+      <div className={clsx(title && 'mt-1 text-sm font-normal')}>{children}</div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/ui/button.tsx
+++ b/apps/dashboard/components/ui/button.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { forwardRef } from 'react';
+import clsx from 'clsx';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-imm-emerald/90 text-imm-emerald-950 shadow-lg shadow-imm-emerald/30 hover:bg-imm-emerald/80 focus:ring-imm-emerald/40 disabled:bg-imm-emerald/60',
+  secondary:
+    'border border-white/15 bg-white/10 text-white shadow-md shadow-black/20 hover:border-white/25 hover:bg-white/20 focus:ring-white/40 disabled:opacity-60',
+  ghost: 'text-white hover:bg-white/10 focus:ring-white/30 disabled:text-white/60',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-3 text-base',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'md', fullWidth, className, type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={clsx(
+        'inline-flex items-center justify-center gap-2 rounded-2xl font-semibold transition focus:outline-none focus:ring-2 disabled:cursor-not-allowed',
+        variantClasses[variant],
+        sizeClasses[size],
+        fullWidth && 'w-full',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Button.displayName = 'Button';

--- a/apps/dashboard/components/ui/card.tsx
+++ b/apps/dashboard/components/ui/card.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import clsx from 'clsx';
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  padding?: 'sm' | 'md' | 'lg';
+}
+
+const paddingStyles = {
+  sm: 'p-4',
+  md: 'p-6',
+  lg: 'p-8',
+};
+
+export function Card({ className, padding = 'md', ...props }: CardProps) {
+  return (
+    <div
+      className={clsx(
+        'rounded-3xl border border-white/10 bg-white/5 shadow-lg shadow-black/20 backdrop-blur-3xl',
+        paddingStyles[padding],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/dashboard/components/ui/input.tsx
+++ b/apps/dashboard/components/ui/input.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { forwardRef } from 'react';
+import clsx from 'clsx';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  hint?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, hint, className, id, disabled, ...props }, ref) => {
+    const inputId = id ?? props.name;
+    return (
+      <label className="flex flex-col gap-2 text-left text-sm font-medium text-slate-200" htmlFor={inputId}>
+        {label}
+        <input
+          ref={ref}
+          id={inputId}
+          disabled={disabled}
+          className={clsx(
+            'w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-imm-emerald/60 focus:outline-none focus:ring-2 focus:ring-imm-emerald/40 disabled:opacity-60',
+            className,
+          )}
+          {...props}
+        />
+        {hint && <span className="text-xs font-normal text-slate-400">{hint}</span>}
+      </label>
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/apps/dashboard/tests/Dashboard.test.tsx
+++ b/apps/dashboard/tests/Dashboard.test.tsx
@@ -38,6 +38,11 @@ const overviewMock = {
   },
 };
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+}));
+
 vi.mock('../hooks/useRequirePermission', () => ({
   useRequirePermission: vi.fn(() => mockSession),
 }));

--- a/apps/dashboard/tests/session.test.ts
+++ b/apps/dashboard/tests/session.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SESSION_EVENT,
+  SESSION_STORAGE_KEY,
+  clearSession,
+  loadSession,
+  saveSession,
+  type StoredSession,
+} from '../lib/session';
+
+describe('session storage helpers', () => {
+  const session: StoredSession = {
+    token: 'token',
+    refreshToken: 'refresh',
+    refreshTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+    permissions: ['analytics:read'],
+    roles: ['admin'],
+    projectScopes: ['project-1'],
+    user: {
+      id: 'user-1',
+      name: 'Ana',
+      email: 'ana@example.com',
+    },
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('persists the session and dispatches an event', () => {
+    const listener = vi.fn();
+    window.addEventListener(SESSION_EVENT, (event) => listener((event as CustomEvent<StoredSession>).detail));
+
+    saveSession(session);
+
+    expect(window.localStorage.getItem(SESSION_STORAGE_KEY)).toBe(JSON.stringify(session));
+    expect(listener).toHaveBeenCalledWith(session);
+  });
+
+  it('loads the stored session when available', () => {
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+
+    expect(loadSession()).toEqual(session);
+  });
+
+  it('clears the session and notifies listeners', () => {
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+    const listener = vi.fn();
+    window.addEventListener(SESSION_EVENT, (event) => listener((event as CustomEvent<StoredSession | null>).detail));
+
+    clearSession();
+
+    expect(window.localStorage.getItem(SESSION_STORAGE_KEY)).toBeNull();
+    expect(listener).toHaveBeenCalledWith(null);
+  });
+});

--- a/docs/frontend/dashboard-integration.md
+++ b/docs/frontend/dashboard-integration.md
@@ -1,0 +1,73 @@
+# Dashboard IMM — Checklist de Integração
+
+Este guia consolida as verificações realizadas no frontend (`apps/dashboard`) e os próximos passos para finalizar a entrega do dashboard institucional.
+
+## 1. Variáveis de ambiente do frontend
+
+O dashboard consome a API Fastify usando `NEXT_PUBLIC_API_URL`. Um arquivo `.env.example` foi incluído no projeto para simplificar a configuração local e em staging.
+
+| Ambiente        | Valor sugerido                      | Observações |
+| --------------- | ----------------------------------- | ----------- |
+| Desenvolvimento | `http://localhost:3333`             | Porta padrão do backend rodando via `npm run dev` ou Docker Compose. |
+| Staging         | `https://staging.api.moveongs.org`  | Ajustar conforme a URL pública configurada no deploy. |
+| Produção        | `https://api.moveongs.org`          | Garantir HTTPS e mapeamento correto no reverse proxy. |
+
+1. Copie `apps/dashboard/.env.example` para `apps/dashboard/.env`.
+2. Atualize `NEXT_PUBLIC_API_URL` de acordo com o ambiente alvo.
+3. Reinicie o servidor Next.js para que o valor seja propagado aos hooks (`fetchJson`).
+
+## 2. Validação do fluxo de autenticação
+
+### Cobertura automatizada
+
+- O teste `apps/dashboard/tests/Login.test.tsx` garante:
+  - Validação de campos obrigatórios.
+  - Tratamento do fluxo de MFA.
+  - Persistência da sessão e redirecionamento pós-login.
+- O novo teste `apps/dashboard/tests/session.test.ts` cobre armazenamento (`localStorage`) e os eventos de sincronização usados pelo hook `useSession`.
+
+Execute os testes com:
+
+```bash
+cd apps/dashboard
+npm run test
+```
+
+### Roteiro manual sugerido
+
+1. Acesse `/(auth)/login` e realize login com credenciais válidas.
+2. Verifique se a sessão é persistida em `localStorage` sob a chave `imm:session`.
+3. Abra outra aba do navegador e confirme se o dashboard reconhece a sessão automaticamente (escuta do evento `imm:session-changed`).
+4. Remova a sessão (logout ou limpeza manual) e valide se o usuário é redirecionado para `/login`.
+
+## 3. Mapa de integrações do dashboard
+
+| Bloco / Hook                              | Endpoint previsto                                      | Status atual | Observações |
+| ----------------------------------------- | ------------------------------------------------------- | ------------ | ----------- |
+| `useAnalyticsOverview`                    | `GET /analytics/overview`                               | ✅ Pronto    | Alimenta KPIs, gráficos e listas principais do dashboard. |
+| `useAnalyticsTimeseries`                  | `GET /analytics/timeseries?metric=...`                  | ✅ Pronto    | Usa filtros globais para renderizar as séries temporais. |
+| `useProjects`                             | `GET /projects`                                         | ✅ Pronto    | Popula filtros de projetos. Confirmar paginação/escopo RBAC. |
+| `useCohorts`                              | `GET /projects/:projectId/cohorts`                      | ⚠️ Verificar | Endpoint precisa garantir filtro por permissões e paginação. |
+| `ExportButtons`                           | `GET /analytics/export?format=csv|pdf`                  | ✅ Pronto    | Já implementado no backend; requer token válido. |
+| `RiskTable` / `ConsentTable`              | Incluídos em `GET /analytics/overview`                  | ✅ Pronto    | Depende do payload de `listas` no overview. |
+| `MessageCenter`                           | `GET /messages`, `GET /messages/:id`                    | 🚧 Pendente | UI mockada. Necessário definir modelo (threads, anexos, status). |
+| `InstitutionalFeed`                       | `GET /institutional-feed`                               | 🚧 Pendente | Conteúdo fictício. Implementar integração com CMS/notifications. |
+| `ActionPlanPanel`                         | `GET /action-plans`, `PATCH /action-plans/:id`          | 🚧 Pendente | Dados mock. Deve conversar com engine de planos/consentimentos. |
+| Uploads/Anexos em mensagens e consentimento | `POST /files`, `GET /files/:id` (S3)                    | 🚧 Pendente | Depende do módulo de anexos em implementação. |
+
+### Próximas ações recomendadas
+
+1. Confirmar com o backend o contrato de `GET /projects/:projectId/cohorts` (paginação, filtros adicionais).
+2. Priorizar as rotas de mensagens/feed/anexos para substituir os dados mockados, alinhando com o roadmap de notificações.
+3. Criar mocks de API (MSW ou interceptadores SWR) para desenvolvimento offline enquanto as rotas pendentes são concluídas.
+
+## 4. Plano de testes integrados
+
+- **React Testing Library + MSW**: simular respostas dos endpoints críticos (`/analytics/overview`, `/analytics/timeseries`, `/projects`). Cobrir renderização do dashboard com filtros aplicados.
+- **Playwright/Cypress (E2E)**:
+  1. Fluxo de login + carregamento do overview (cenário feliz).
+  2. Usuário sem permissão `analytics:read` → redirecionamento/controlar acesso.
+  3. Exportação CSV/PDF com verificação de download iniciado.
+- **Contratos Backend-Frontend**: adicionar testes de contrato (pode ser via `vitest` no backend) para garantir estabilidade dos payloads usados pelo frontend.
+
+Com esses passos, o dashboard fica alinhado às necessidades do Instituto Move Marias e pronto para conectar novas funcionalidades (mensagens, anexos e formulários dinâmicos).


### PR DESCRIPTION
## Summary
- add an `.env.example` and documentation covering dashboard environment setup, authentication checks, and pending API integrations
- introduce reusable “liquid glass” UI primitives (button, input, card, alert) and refactor the login page and export buttons to use them
- extend the dashboard test suite with session storage coverage and proper Next.js router mocking

## Testing
- `cd apps/dashboard && npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d53e7ccd108324a77094ae083591d9