### PR TITLE
feat(forms): add template revision registry

### DIFF
--- a/artifacts/sql/0001_initial.sql
+++ b/artifacts/sql/0001_initial.sql
@@ -88,6 +88,23 @@ create table if not exists form_templates (
   unique (form_type, schema_version)
 );
 
+create table if not exists form_template_revisions (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references form_templates(id) on delete cascade,
+  form_type text not null,
+  schema_version text not null,
+  revision int not null,
+  schema jsonb not null,
+  status text not null,
+  published_at timestamptz,
+  created_at timestamptz default now(),
+  created_by uuid references users(id),
+  unique (template_id, revision)
+);
+
+create index if not exists form_template_revisions_lookup
+  on form_template_revisions (form_type, schema_version, revision desc);
+
 create table if not exists form_submissions (
   id uuid primary key default gen_random_uuid(),
   beneficiary_id uuid references beneficiaries(id) on delete cascade,

--- a/src/modules/forms/service.ts
+++ b/src/modules/forms/service.ts
@@ -11,6 +11,7 @@ import type {
   FormSubmissionRecord,
   FormSubmissionSummary,
   FormTemplateRecord,
+  FormTemplateRevisionRecord,
   ListSubmissionsFilters,
   ListTemplatesFilters,
   UpdateSubmissionParams,
@@ -23,6 +24,7 @@ import {
   getLatestActiveTemplate,
   getTemplateById,
   getTemplateByTypeAndVersion,
+  listTemplateRevisions as listTemplateRevisionsRepository,
   listFormTemplates as listFormTemplatesRepository,
   listSubmissionsByBeneficiary,
   updateFormSubmission as updateFormSubmissionRepository,
@@ -37,11 +39,15 @@ export async function listFormTemplates(filters: ListTemplatesFilters): Promise<
 }
 
 export async function createFormTemplate(input: CreateTemplateParams): Promise<FormTemplateRecord> {
-  return createFormTemplateRepository(input);
+  return createFormTemplateRepository({ ...input, createdBy: input.createdBy ?? null });
 }
 
 export async function updateFormTemplate(id: string, input: UpdateTemplateParams): Promise<FormTemplateRecord> {
-  return updateFormTemplateRepository(id, input);
+  return updateFormTemplateRepository(id, { ...input, updatedBy: input.updatedBy ?? null });
+}
+
+export async function listTemplateRevisions(templateId: string): Promise<FormTemplateRevisionRecord[]> {
+  return listTemplateRevisionsRepository(templateId);
 }
 
 export async function getFormTemplateOrFail(id: string): Promise<FormTemplateRecord> {

--- a/src/modules/forms/types.ts
+++ b/src/modules/forms/types.ts
@@ -7,6 +7,19 @@ export type FormTemplateRecord = {
   publishedAt: string | null;
 };
 
+export type FormTemplateRevisionRecord = {
+  id: string;
+  templateId: string;
+  formType: string;
+  schemaVersion: string;
+  revision: number;
+  schema: unknown;
+  status: string;
+  publishedAt: string | null;
+  createdAt: string;
+  createdBy: string | null;
+};
+
 export type FormAttachment = {
   id?: string;
   fileName?: string | null;
@@ -45,11 +58,13 @@ export type CreateTemplateParams = {
   schemaVersion: string;
   schema: unknown;
   status?: string;
+  createdBy?: string | null;
 };
 
 export type UpdateTemplateParams = {
   schema?: unknown;
   status?: string;
+  updatedBy?: string | null;
 };
 
 export type ListSubmissionsFilters = {


### PR DESCRIPTION
## Summary
- create a `form_template_revisions` table to persist audit history for each template version
- record revision entries whenever templates are seeded, created or updated and keep track of the acting user
- expose revision data through the forms service and a dedicated `/form-templates/:id/revisions` API endpoint

## Testing
- npm run check *(fails: repository contains unresolved MFA/notifications TypeScript typing issues)*
- npm test *(aborted after ~1 min: vitest run hangs while waiting on analytics suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d547f74be88324813af85b90acd2cd