### PR TITLE
feat(messages): add retention metadata, attachments and mentions

### DIFF
--- a/artifacts/sql/0001_initial.sql
+++ b/artifacts/sql/0001_initial.sql
@@ -217,6 +217,9 @@ create table if not exists threads (
   created_by uuid references users(id),
   subject text,
   visibility text default 'internal',
+  classification text default 'publico_interno',
+  retention_expires_at timestamptz,
+  search_terms text[] default '{}'::text[],
   created_at timestamptz default now()
 );
 
@@ -233,6 +236,11 @@ create table if not exists messages (
   body text not null,
   visibility text default 'internal',
   is_confidential boolean default false,
+  classification text default 'publico_interno',
+  retention_expires_at timestamptz,
+  mentions uuid[] default '{}'::uuid[],
+  attachment_ids uuid[] default '{}'::uuid[],
+  search_terms text[] default '{}'::text[],
   created_at timestamptz default now(),
   updated_at timestamptz default now()
 );

--- a/src/modules/messages/routes.ts
+++ b/src/modules/messages/routes.ts
@@ -24,6 +24,8 @@ export const messageRoutes: FastifyPluginAsync = async (app) => {
     const threads = await listThreads({
       userId: request.user.sub,
       scope: parsed.data.scope,
+      search: parsed.data.search,
+      classifications: parsed.data.classifications,
     });
 
     return { data: threads };
@@ -45,6 +47,9 @@ export const messageRoutes: FastifyPluginAsync = async (app) => {
       scope: parsed.data.scope,
       subject: parsed.data.subject ?? null,
       visibility: parsed.data.visibility,
+      classification: parsed.data.classification,
+      retentionExpiresAt: parsed.data.retentionExpiresAt ?? null,
+      searchTerms: parsed.data.searchTerms,
       memberIds: uniqueMemberIds,
       initialMessage: parsed.data.initialMessage,
       roles: request.user.roles ?? [],
@@ -113,6 +118,11 @@ export const messageRoutes: FastifyPluginAsync = async (app) => {
       body: parsedBody.data.body,
       visibility: parsedBody.data.visibility,
       isConfidential: parsedBody.data.isConfidential,
+      classification: parsedBody.data.classification,
+      retentionExpiresAt: parsedBody.data.retentionExpiresAt ?? null,
+      mentions: parsedBody.data.mentions,
+      attachments: parsedBody.data.attachments,
+      searchTerms: parsedBody.data.searchTerms,
       roles: request.user.roles ?? [],
       permissions: request.user.permissions ?? [],
     });

--- a/src/modules/messages/schemas.ts
+++ b/src/modules/messages/schemas.ts
@@ -2,25 +2,62 @@ import { z } from 'zod';
 
 export const threadVisibilitySchema = z.enum(['internal', 'project', 'private']);
 export const messageVisibilitySchema = z.enum(['internal', 'project', 'private']);
+export const retentionClassificationSchema = z.enum(['publico_interno', 'sensivel', 'confidencial']);
+
+const retentionExpiresAtSchema = z
+  .string()
+  .datetime({ message: 'Data de retenção inválida' })
+  .nullable()
+  .optional();
+
+const searchTermsSchema = z
+  .array(z.string().trim().min(1).max(200))
+  .max(25)
+  .optional();
+
+const mentionIdsSchema = z.array(z.string().uuid()).max(50).optional();
+const attachmentIdsSchema = z.array(z.string().uuid()).max(20).optional();
 
 export const threadIdParamSchema = z.object({
   id: z.string().uuid(),
 });
 
-export const listThreadsQuerySchema = z.object({
-  scope: z.string().trim().min(1).max(120).optional(),
-});
+export const listThreadsQuerySchema = z
+  .object({
+    scope: z.string().trim().min(1).max(120).optional(),
+    search: z.string().trim().min(2).max(200).optional(),
+    classification: z
+      .union([retentionClassificationSchema, z.array(retentionClassificationSchema)])
+      .optional(),
+  })
+  .transform((value) => ({
+    scope: value.scope,
+    search: value.search,
+    classifications: value.classification
+      ? Array.isArray(value.classification)
+        ? Array.from(new Set(value.classification))
+        : [value.classification]
+      : undefined,
+  }));
 
 export const createThreadBodySchema = z.object({
   scope: z.string().trim().min(1).max(120),
   subject: z.string().trim().min(1).max(200).nullable().optional(),
   visibility: threadVisibilitySchema.optional(),
+  classification: retentionClassificationSchema.optional(),
+  retentionExpiresAt: retentionExpiresAtSchema,
+  searchTerms: searchTermsSchema,
   memberIds: z.array(z.string().uuid()).max(50).optional().default([]),
   initialMessage: z
     .object({
       body: z.string().trim().min(1).max(5000),
       visibility: messageVisibilitySchema.optional(),
       isConfidential: z.boolean().optional(),
+      classification: retentionClassificationSchema.optional(),
+      retentionExpiresAt: retentionExpiresAtSchema,
+      mentions: mentionIdsSchema,
+      attachments: attachmentIdsSchema,
+      searchTerms: searchTermsSchema,
     })
     .optional(),
 });
@@ -29,4 +66,9 @@ export const createMessageBodySchema = z.object({
   body: z.string().trim().min(1).max(5000),
   visibility: messageVisibilitySchema.optional(),
   isConfidential: z.boolean().optional(),
+  classification: retentionClassificationSchema.optional(),
+  retentionExpiresAt: retentionExpiresAtSchema,
+  mentions: mentionIdsSchema,
+  attachments: attachmentIdsSchema,
+  searchTerms: searchTermsSchema,
 });


### PR DESCRIPTION
## Summary
- extend the messages schema to record classification, retention, mentions, attachments and search metadata for threads and posts
- update repository and service layers to persist the new metadata, validate mentions and support filtered thread queries
- expose the additional fields through request schemas and routes so clients can set retention policies, mentions, attachments and search terms

## Testing
- `npm run check` *(fails: existing missing webauthn/notification type definitions in other modules)*
- `npm test` *(partially executed; aborted after ~30s with remaining suites still queued)*

------
https://chatgpt.com/codex/tasks/task_e_68d579fe222083249735f1ef626d56be