### PR TITLE
Cast allowed project array parameter to uuid array

### DIFF
--- a/src/modules/analytics/service.ts
+++ b/src/modules/analytics/service.ts
@@ -82,7 +82,7 @@ function applyProjectFilters(
     whereParts.push(`${projectColumn} = $${values.length}`);
   } else if (filters.allowedProjectIds && filters.allowedProjectIds.length > 0) {
     values.push(filters.allowedProjectIds);
-    whereParts.push(`${projectColumn} = any($${values.length})`);
+    whereParts.push(`${projectColumn} = any($${values.length}::uuid[])`);
   }
 
   if (filters.cohortId) {


### PR DESCRIPTION
## Summary
- ensure analytics project filter casts allowed project id arrays to uuid[] to prevent type mismatches

## Testing
- npx vitest run tests/analytics.service.test.ts tests/analytics.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6892efb108324a06b5fb1aada2c20