### PR TITLE
Fix duplicated notification delivery counts

### DIFF
--- a/src/modules/notifications/service.ts
+++ b/src/modules/notifications/service.ts
@@ -96,7 +96,6 @@ const notificationQueue = new JobQueue<NotificationQueueJob>(async (job) => {
     return;
   }
 
-  const startTime = Date.now();
   switch (job.channel) {
     case 'email':
       await emailAdapter.send(job.payload);
@@ -108,10 +107,8 @@ const notificationQueue = new JobQueue<NotificationQueueJob>(async (job) => {
       await webhookAdapter.send(job.payload);
       break;
   }
-  const durationMs = Date.now() - startTime;
 
   state.processedJobKeys.add(job.dedupeKey);
-  metrics.recordSuccess(job.channel, durationMs);
 }, {
   concurrency: queueOptions.concurrency,
   maxAttempts: queueOptions.maxAttempts,

--- a/tests/notifications.service.test.ts
+++ b/tests/notifications.service.test.ts
@@ -298,10 +298,10 @@ describe('notification service', () => {
     await waitForNotificationQueue();
 
     const metrics = getNotificationMetricsSnapshot();
-    expect(metrics.email.delivered).toBeGreaterThanOrEqual(1);
-    expect(metrics.whatsapp.delivered).toBeGreaterThanOrEqual(1);
+    expect(metrics.email.delivered).toBe(1);
+    expect(metrics.whatsapp.delivered).toBe(1);
     expect(metrics.webhook.delivered).toBe(0);
-    expect(metrics.email.averageProcessingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.email.averageProcessingTimeMs).toBeGreaterThan(0);
   });
 
   it('é idempotente por evento e canal', async () => {


### PR DESCRIPTION
## Summary
- rely on notification adapters to report successful deliveries so the queue no longer double counts
- tighten the metrics test to assert exact delivery totals and positive processing duration

## Testing
- npm test -- tests/notifications.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d68d21dee483249495c788ceb399a4