### PR TITLE
refactor: rely on adapter metrics

### DIFF
--- a/src/modules/notifications/service.ts
+++ b/src/modules/notifications/service.ts
@@ -96,7 +96,6 @@ const notificationQueue = new JobQueue<NotificationQueueJob>(async (job) => {
     return;
   }
 
-  const startTime = Date.now();
   switch (job.channel) {
     case 'email':
       await emailAdapter.send(job.payload);
@@ -108,10 +107,8 @@ const notificationQueue = new JobQueue<NotificationQueueJob>(async (job) => {
       await webhookAdapter.send(job.payload);
       break;
   }
-  const durationMs = Date.now() - startTime;
 
   state.processedJobKeys.add(job.dedupeKey);
-  metrics.recordSuccess(job.channel, durationMs);
 }, {
   concurrency: queueOptions.concurrency,
   maxAttempts: queueOptions.maxAttempts,


### PR DESCRIPTION
## Summary
- remove duplicate success metric recording from the notification queue handler so adapters remain the sole source of truth

## Testing
- npm test -- tests/notifications.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d68dd390a4832489facff7ea5dcb1e