### PR TITLE
Ensure notification metrics reflect dispatch counts

### DIFF
--- a/tests/notifications.service.test.ts
+++ b/tests/notifications.service.test.ts
@@ -297,10 +297,16 @@ describe('notification service', () => {
 
     await waitForNotificationQueue();
 
+    const emails = getEmailDispatchHistory();
+    const whatsapps = getWhatsappDispatchHistory();
+    expect(emails).toHaveLength(1);
+    expect(whatsapps).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
     const metrics = getNotificationMetricsSnapshot();
-    expect(metrics.email.delivered).toBe(1);
-    expect(metrics.whatsapp.delivered).toBe(1);
-    expect(metrics.webhook.delivered).toBe(0);
+    expect(metrics.email.delivered).toBe(emails.length);
+    expect(metrics.whatsapp.delivered).toBe(whatsapps.length);
+    expect(metrics.webhook.delivered).toBe(fetchMock.mock.calls.length);
     expect(metrics.email.averageProcessingTimeMs).toBeGreaterThan(0);
   });
 
@@ -331,6 +337,8 @@ describe('notification service', () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     const metrics = getNotificationMetricsSnapshot();
+    expect(metrics.email.delivered).toBe(emails.length);
+    expect(metrics.whatsapp.delivered).toBe(whatsapps.length);
     expect(metrics.email.duplicates).toBeGreaterThanOrEqual(1);
     expect(metrics.whatsapp.duplicates).toBeGreaterThanOrEqual(1);
   });


### PR DESCRIPTION
## Summary
- update the notification service tests to assert that delivery metrics mirror the actual email, WhatsApp, and webhook dispatch history
- extend the idempotency test to confirm delivered counts stay aligned with history when duplicate events are published

## Testing
- npm test -- tests/notifications.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d68e820f308324af07ca4c2bdfa32f