### PR TITLE
feat: connect dashboard enrollments and action plans to API

### DIFF
--- a/apps/dashboard/app/action-plans/page.tsx
+++ b/apps/dashboard/app/action-plans/page.tsx
@@ -1,87 +1,162 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
 import { Shell } from '../../components/Shell';
 import { PrimarySidebar } from '../../components/PrimarySidebar';
 import { useRequirePermission } from '../../hooks/useRequirePermission';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
 import {
-  demoBeneficiaries,
-  demoActionPlans,
-  getActionPlanByBeneficiary,
-  type DemoActionPlan,
-  type DemoActionPlanTask,
-} from '../../lib/demo-data';
+  listBeneficiaries,
+  listActionPlans,
+  createActionPlan,
+  createActionPlanItem,
+  updateActionPlanItem,
+  type BeneficiarySummary,
+  type PaginationMeta,
+  type ActionPlanRecord,
+  type ActionPlanItemRecord,
+} from '../../lib/operations';
 
-const STATUS_LABELS: Record<DemoActionPlanTask['status'], string> = {
-  planejada: 'Planejada',
-  em_andamento: 'Em andamento',
-  concluida: 'Concluída',
-  atrasada: 'Atrasada',
+const STATUS_LABELS: Record<ActionItemStatus, string> = {
+  pending: 'Planejada',
+  in_progress: 'Em andamento',
+  blocked: 'Bloqueada',
+  done: 'Concluída',
 };
 
-const STATUS_ORDER: DemoActionPlanTask['status'][] = ['planejada', 'em_andamento', 'atrasada', 'concluida'];
+const STATUS_ORDER: ActionItemStatus[] = ['pending', 'in_progress', 'blocked', 'done'];
+
+type ActionItemStatus = 'pending' | 'in_progress' | 'blocked' | 'done';
+
+type BeneficiariesResponse = { data: BeneficiarySummary[]; meta: PaginationMeta };
+
+type ActionPlansResponse = ActionPlanRecord[];
 
 export default function ActionPlansPage() {
-  const session = useRequirePermission(['action-plans:read', 'action-plans:write']);
-  const [selectedBeneficiaryId, setSelectedBeneficiaryId] = useState<string>(demoBeneficiaries[0]?.id ?? '');
-  const [plans, setPlans] = useState<Record<string, DemoActionPlan>>(
-    Object.fromEntries(demoActionPlans.map((plan) => [plan.beneficiaryId, plan]))
+  const session = useRequirePermission(['action_plans:read', 'action_plans:update', 'action_plans:create']);
+  const [selectedBeneficiaryId, setSelectedBeneficiaryId] = useState<string>('');
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [isCreatingPlan, setIsCreatingPlan] = useState(false);
+  const [isCreatingTask, setIsCreatingTask] = useState(false);
+  const [updatingItemId, setUpdatingItemId] = useState<string | null>(null);
+
+  const beneficiariesKey = useMemo(() => {
+    if (!session) return null;
+    return ['beneficiaries:list', 'action-plans', session.token] as const;
+  }, [session]);
+
+  const { data: beneficiariesResponse, isLoading: loadingBeneficiaries } = useSWR<BeneficiariesResponse>(
+    beneficiariesKey,
+    ([, , token]) => listBeneficiaries({ limit: 50 }, token),
   );
 
-  const plan = plans[selectedBeneficiaryId] ?? getActionPlanByBeneficiary(selectedBeneficiaryId) ?? null;
-  const primarySidebar = useMemo(() => (session ? <PrimarySidebar session={session} /> : null), [session]);
+  useEffect(() => {
+    if (beneficiariesResponse?.data?.length && !selectedBeneficiaryId) {
+      setSelectedBeneficiaryId(beneficiariesResponse.data[0].id);
+    }
+  }, [beneficiariesResponse, selectedBeneficiaryId]);
+
+  const actionPlansKey = useMemo(() => {
+    if (!session || !selectedBeneficiaryId) return null;
+    return ['action-plans:list', selectedBeneficiaryId, session.token] as const;
+  }, [session, selectedBeneficiaryId]);
+
+  const {
+    data: actionPlans,
+    isLoading: loadingPlans,
+    mutate: mutatePlans,
+  } = useSWR<ActionPlansResponse>(actionPlansKey, ([, beneficiaryId, token]) =>
+    listActionPlans(beneficiaryId, { status: 'active' }, token),
+  );
+
+  const plan = actionPlans?.[0] ?? null;
+
+  useEffect(() => {
+    if (feedback) {
+      const timeout = setTimeout(() => setFeedback(null), 4000);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [feedback]);
 
   if (session === undefined) {
     return null;
   }
 
-  const handleStatusChange = (taskId: string, status: DemoActionPlanTask['status']) => {
-    if (!plan) return;
-    setPlans((prev) => {
-      const current = prev[selectedBeneficiaryId] ?? plan;
-      return {
-        ...prev,
-        [selectedBeneficiaryId]: {
-          ...current,
-          tasks: current.tasks.map((task) => (task.id === taskId ? { ...task, status } : task)),
-        },
-      };
-    });
+  const handleCreatePlan = async () => {
+    if (!session || !selectedBeneficiaryId) return;
+    setIsCreatingPlan(true);
+    try {
+      await createActionPlan({ beneficiaryId: selectedBeneficiaryId }, session.token);
+      await mutatePlans();
+      setFeedback({ type: 'success', message: 'Plano de ação criado com sucesso.' });
+    } catch (error) {
+      console.error(error);
+      setFeedback({ type: 'error', message: 'Não foi possível criar o plano. Tente novamente.' });
+    } finally {
+      setIsCreatingPlan(false);
+    }
   };
 
-  const handleAddTask = () => {
-    if (!plan) return;
+  const handleStatusChange = async (taskId: string, status: ActionItemStatus) => {
+    if (!session || !plan) return;
+    setUpdatingItemId(taskId);
+    try {
+      await updateActionPlanItem(
+        plan.id,
+        taskId,
+        {
+          status,
+          completedAt: status === 'done' ? new Date().toISOString().slice(0, 10) : null,
+        },
+        session.token,
+      );
+      await mutatePlans();
+      setFeedback({ type: 'success', message: 'Status da ação atualizado.' });
+    } catch (error) {
+      console.error(error);
+      setFeedback({ type: 'error', message: 'Não foi possível atualizar a ação.' });
+    } finally {
+      setUpdatingItemId(null);
+    }
+  };
+
+  const handleAddTask = async () => {
+    if (!session || !plan) return;
     const title = prompt('Descreva a nova ação do plano');
     if (!title) return;
 
-    const newTask: DemoActionPlanTask = {
-      id: `task-${Date.now()}`,
-      title,
-      status: 'planejada',
-      responsible: plan.owner.split(': ')[1] ?? 'Equipe IMM',
-      dueDate: new Date().toISOString().slice(0, 10),
-      support: 'Definir recursos necessários',
-    };
-
-    setPlans((prev) => {
-      const current = prev[selectedBeneficiaryId] ?? plan;
-      return {
-        ...prev,
-        [selectedBeneficiaryId]: {
-          ...current,
-          tasks: [newTask, ...current.tasks],
+    setIsCreatingTask(true);
+    try {
+      await createActionPlanItem(
+        plan.id,
+        {
+          title,
+          status: 'pending',
+          responsible: 'Equipe IMM',
+          dueDate: new Date().toISOString().slice(0, 10),
         },
-      };
-    });
+        session.token,
+      );
+      await mutatePlans();
+      setFeedback({ type: 'success', message: 'Ação adicionada ao plano.' });
+    } catch (error) {
+      console.error(error);
+      setFeedback({ type: 'error', message: 'Não foi possível adicionar a ação.' });
+    } finally {
+      setIsCreatingTask(false);
+    }
   };
+
+  const beneficiaries = beneficiariesResponse?.data ?? [];
 
   return (
     <Shell
       title="Plano de ação personalizado"
       description="Monitore objetivos, tarefas, responsáveis e prazos das beneficiárias acompanhadas pela equipe técnica."
-      sidebar={primarySidebar}
+      sidebar={session ? <PrimarySidebar session={session} /> : null}
     >
       <div className="grid gap-6 xl:grid-cols-[1fr_2fr]">
         <Card className="space-y-4" padding="lg">
@@ -90,14 +165,29 @@ export default function ActionPlansPage() {
             <h2 className="text-xl font-semibold text-white">Selecione para visualizar o plano</h2>
           </header>
 
+          {feedback && (
+            <div
+              className={`rounded-3xl border p-4 text-sm ${
+                feedback.type === 'success'
+                  ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-100'
+                  : 'border-rose-400/40 bg-rose-500/10 text-rose-100'
+              }`}
+            >
+              {feedback.message}
+            </div>
+          )}
+
           <select
             value={selectedBeneficiaryId}
             onChange={(event) => setSelectedBeneficiaryId(event.target.value)}
             className="w-full rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/80 focus:border-emerald-400 focus:outline-none"
+            disabled={loadingBeneficiaries}
           >
-            {demoBeneficiaries.map((beneficiary) => (
+            {loadingBeneficiaries && <option value="">Carregando beneficiárias...</option>}
+            {!loadingBeneficiaries && beneficiaries.length === 0 && <option value="">Nenhuma beneficiária disponível</option>}
+            {beneficiaries.map((beneficiary) => (
               <option key={beneficiary.id} value={beneficiary.id}>
-                {beneficiary.name}
+                {beneficiary.fullName}
               </option>
             ))}
           </select>
@@ -105,16 +195,16 @@ export default function ActionPlansPage() {
           {plan ? (
             <div className="space-y-4 text-sm text-white/80">
               <div>
-                <h3 className="text-xs uppercase tracking-[0.24em] text-white/40">Objetivo</h3>
-                <p className="text-white">{plan.objective}</p>
-              </div>
-              <div>
-                <h3 className="text-xs uppercase tracking-[0.24em] text-white/40">Responsável</h3>
-                <p>{plan.owner}</p>
+                <h3 className="text-xs uppercase tracking-[0.24em] text-white/40">Status do plano</h3>
+                <p className="text-white">{plan.status === 'completed' ? 'Concluído' : plan.status === 'archived' ? 'Arquivado' : 'Ativo'}</p>
               </div>
               <div>
                 <h3 className="text-xs uppercase tracking-[0.24em] text-white/40">Criado em</h3>
-                <p>{plan.createdAt}</p>
+                <p>{formatDate(plan.createdAt)}</p>
+              </div>
+              <div>
+                <h3 className="text-xs uppercase tracking-[0.24em] text-white/40">Última atualização</h3>
+                <p>{formatDate(plan.updatedAt)}</p>
               </div>
             </div>
           ) : (
@@ -122,30 +212,45 @@ export default function ActionPlansPage() {
           )}
 
           <div className="flex flex-wrap gap-3">
-            <Button type="button" onClick={handleAddTask} disabled={!plan}>
-              Adicionar ação
+            <Button type="button" onClick={handleAddTask} disabled={!plan || isCreatingTask}>
+              {isCreatingTask ? 'Adicionando...' : 'Adicionar ação'}
             </Button>
-            <Button type="button" variant="secondary">
-              Exportar plano completo
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleCreatePlan}
+              disabled={isCreatingPlan || Boolean(plan)}
+            >
+              {plan ? 'Plano ativo' : isCreatingPlan ? 'Criando...' : 'Criar plano'}
             </Button>
           </div>
         </Card>
 
-        {plan ? <TasksBoard plan={plan} onStatusChange={handleStatusChange} /> : <EmptyPlanState />}
+        {loadingPlans ? (
+          <Card className="space-y-3" padding="lg">
+            <h3 className="text-lg font-semibold text-white">Carregando plano de ação</h3>
+            <p className="text-sm text-white/70">Aguarde enquanto buscamos as ações registradas para esta beneficiária.</p>
+          </Card>
+        ) : plan ? (
+          <TasksBoard plan={plan} onStatusChange={handleStatusChange} updatingItemId={updatingItemId} />
+        ) : (
+          <EmptyPlanState />
+        )}
       </div>
     </Shell>
   );
 }
 
 interface TasksBoardProps {
-  plan: DemoActionPlan;
-  onStatusChange: (taskId: string, status: DemoActionPlanTask['status']) => void;
+  plan: ActionPlanRecord;
+  onStatusChange: (taskId: string, status: ActionItemStatus) => void;
+  updatingItemId: string | null;
 }
 
-function TasksBoard({ plan, onStatusChange }: TasksBoardProps) {
+function TasksBoard({ plan, onStatusChange, updatingItemId }: TasksBoardProps) {
   const grouped = STATUS_ORDER.map((status) => ({
     status,
-    tasks: plan.tasks.filter((task) => task.status === status),
+    tasks: plan.items.filter((task) => task.status === status),
   }));
 
   return (
@@ -161,32 +266,7 @@ function TasksBoard({ plan, onStatusChange }: TasksBoardProps) {
             {column.tasks.length === 0 && <li className="text-xs text-white/40">Nenhuma ação nesta coluna.</li>}
             {column.tasks.map((task) => (
               <li key={task.id} className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-                <div>
-                  <p className="font-semibold text-white">{task.title}</p>
-                  <p className="text-xs text-white/60">Responsável: {task.responsible}</p>
-                  <p className="text-xs text-white/60">Prazo: {task.dueDate}</p>
-                </div>
-                {task.support && <p className="text-xs text-white/60">Suporte IMM: {task.support}</p>}
-                {task.notes && <p className="text-xs text-white/60">Notas: {task.notes}</p>}
-                <div className="flex flex-wrap gap-2">
-                  {STATUS_ORDER.map((status) => {
-                    const isActive = status === task.status;
-                    return (
-                      <button
-                        key={status}
-                        type="button"
-                        onClick={() => onStatusChange(task.id, status)}
-                        className={`rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.2em] transition ${
-                          isActive
-                            ? 'border-emerald-400/60 bg-emerald-500/20 text-emerald-100'
-                            : 'border-white/10 bg-white/5 text-white/60 hover:border-white/30 hover:bg-white/10'
-                        }`}
-                      >
-                        {STATUS_LABELS[status]}
-                      </button>
-                    );
-                  })}
-                </div>
+                <TaskCard task={task} updating={updatingItemId === task.id} onStatusChange={onStatusChange} />
               </li>
             ))}
           </ul>
@@ -196,11 +276,62 @@ function TasksBoard({ plan, onStatusChange }: TasksBoardProps) {
   );
 }
 
+interface TaskCardProps {
+  task: ActionPlanItemRecord;
+  updating: boolean;
+  onStatusChange: (taskId: string, status: ActionItemStatus) => void;
+}
+
+function TaskCard({ task, updating, onStatusChange }: TaskCardProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="font-semibold text-white">{task.title}</p>
+        {task.responsible && <p className="text-xs text-white/60">Responsável: {task.responsible}</p>}
+        {task.dueDate && <p className="text-xs text-white/60">Prazo: {formatDate(task.dueDate)}</p>}
+      </div>
+      {task.support && <p className="text-xs text-white/60">Suporte IMM: {task.support}</p>}
+      {task.notes && <p className="text-xs text-white/60">Notas: {task.notes}</p>}
+      <div className="flex flex-wrap gap-2">
+        {STATUS_ORDER.map((status) => {
+          const isActive = status === task.status;
+          return (
+            <button
+              key={status}
+              type="button"
+              onClick={() => onStatusChange(task.id, status)}
+              disabled={updating || isActive}
+              className={`rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.2em] transition ${
+                isActive
+                  ? 'border-emerald-400/60 bg-emerald-500/20 text-emerald-100'
+                  : 'border-white/10 bg-white/5 text-white/60 hover:border-white/30 hover:bg-white/10 disabled:opacity-40'
+              }`}
+            >
+              {STATUS_LABELS[status]}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function EmptyPlanState() {
   return (
-    <Card className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-white/60" padding="lg">
-      <p>Nenhum plano encontrado para esta beneficiária.</p>
-      <p className="text-xs text-white/40">Cadastre um plano via API ou use o fluxo de onboarding para iniciar um plano personalizado.</p>
+    <Card className="space-y-4" padding="lg">
+      <h3 className="text-lg font-semibold text-white">Nenhum plano cadastrado</h3>
+      <p className="text-sm text-white/70">
+        Selecione uma beneficiária com plano ativo ou utilize o botão de criação para iniciar um acompanhamento personalizado.
+      </p>
     </Card>
   );
+}
+
+function formatDate(value: string) {
+  try {
+    return new Date(value).toLocaleDateString('pt-BR');
+  } catch (error) {
+    console.error(error);
+    return value;
+  }
 }

--- a/apps/dashboard/app/enrollments/page.tsx
+++ b/apps/dashboard/app/enrollments/page.tsx
@@ -1,74 +1,179 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
 import { Shell } from '../../components/Shell';
 import { PrimarySidebar } from '../../components/PrimarySidebar';
 import { useRequirePermission } from '../../hooks/useRequirePermission';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
 import {
-  demoBeneficiaries,
-  demoCohorts,
-  demoProjects,
-  type DemoBeneficiary,
-  type DemoCohort,
-  type DemoProject,
-} from '../../lib/demo-data';
+  listProjects,
+  listProjectCohorts,
+  listBeneficiaries,
+  listEnrollments,
+  createEnrollment,
+  type ProjectRecord,
+  type CohortRecord,
+  type BeneficiarySummary,
+  type EnrollmentRecord,
+  type PaginationMeta,
+} from '../../lib/operations';
 
-interface LocalEnrollment {
-  id: string;
-  beneficiary: DemoBeneficiary;
-  project: DemoProject;
-  cohort: DemoCohort;
-  startDate: string;
-  status: 'ativa' | 'aguardando' | 'pendente';
-}
+const ENROLLMENT_PAGE_SIZE = 10;
+
+const ENROLLMENT_STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  active: { label: 'Ativa', className: 'bg-emerald-500/20 text-emerald-100 border-emerald-400/40' },
+  suspended: { label: 'Suspensa', className: 'bg-amber-500/15 text-amber-100 border-amber-400/30' },
+  terminated: { label: 'Desligada', className: 'bg-rose-500/15 text-rose-100 border-rose-400/30' },
+};
 
 export default function EnrollmentsPage() {
-  const session = useRequirePermission(['enrollments:create']);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>(demoProjects[0]?.id ?? '');
+  const session = useRequirePermission(['enrollments:read:project', 'enrollments:create:project']);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>('');
   const [selectedCohortId, setSelectedCohortId] = useState<string>('');
   const [selectedBeneficiaryId, setSelectedBeneficiaryId] = useState<string>('');
-  const [startDate, setStartDate] = useState<string>(new Date().toISOString().slice(0, 10));
-  const [enrollments, setEnrollments] = useState<LocalEnrollment[]>([]);
+  const [startDate, setStartDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
+  const [beneficiarySearch, setBeneficiarySearch] = useState('');
+  const [enrollmentOffset, setEnrollmentOffset] = useState(0);
+  const [isCreating, setIsCreating] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
-  const primarySidebar = useMemo(() => (session ? <PrimarySidebar session={session} /> : null), [session]);
-  const availableCohorts = demoCohorts.filter((cohort) => cohort.projectId === selectedProjectId);
-  const project = demoProjects.find((item) => item.id === selectedProjectId) ?? demoProjects[0];
+  const projectsKey = useMemo(() => {
+    if (!session) return null;
+    return ['projects:list', session.token] as const;
+  }, [session]);
+
+  const { data: projects, isLoading: loadingProjects } = useSWR<ProjectRecord[]>(
+    projectsKey,
+    ([, token]) => listProjects(token),
+  );
+
+  useEffect(() => {
+    if (projects?.length && !selectedProjectId) {
+      setSelectedProjectId(projects[0].id);
+    }
+  }, [projects, selectedProjectId]);
+
+  const cohortsKey = useMemo(() => {
+    if (!session || !selectedProjectId) return null;
+    return ['projects:cohorts', selectedProjectId, session.token] as const;
+  }, [session, selectedProjectId]);
+
+  const { data: cohorts, isLoading: loadingCohorts } = useSWR<CohortRecord[]>(
+    cohortsKey,
+    ([, projectId, token]) => listProjectCohorts(projectId, token),
+  );
+
+  useEffect(() => {
+    if (!cohorts || cohorts.length === 0) {
+      setSelectedCohortId('');
+      return;
+    }
+    setSelectedCohortId((current) => (cohorts.some((cohort) => cohort.id === current) ? current : cohorts[0].id));
+  }, [cohorts]);
+
+  const beneficiariesKey = useMemo(() => {
+    if (!session) return null;
+    return ['beneficiaries:list', beneficiarySearch, session.token] as const;
+  }, [session, beneficiarySearch]);
+
+  const { data: beneficiariesResponse, isLoading: loadingBeneficiaries } = useSWR<
+    { data: BeneficiarySummary[]; meta: PaginationMeta }
+  >(
+    beneficiariesKey,
+    ([, searchTerm, token]) => listBeneficiaries({ search: searchTerm, limit: 50 }, token),
+  );
+
+  const beneficiaries = beneficiariesResponse?.data ?? [];
+
+  const enrollmentsKey = useMemo(() => {
+    if (!session) return null;
+    return [
+      'enrollments:list',
+      selectedProjectId || null,
+      selectedCohortId || null,
+      enrollmentOffset,
+      session.token,
+    ] as const;
+  }, [session, selectedProjectId, selectedCohortId, enrollmentOffset]);
+
+  const {
+    data: enrollmentResponse,
+    isLoading: loadingEnrollments,
+    mutate: mutateEnrollments,
+  } = useSWR<EnrollmentListResponse | undefined>(enrollmentsKey, ([, projectId, cohortId, offset, token]) =>
+    listEnrollments(
+      {
+        projectId: projectId ?? undefined,
+        cohortId: cohortId ?? undefined,
+        limit: ENROLLMENT_PAGE_SIZE,
+        offset,
+      },
+      token,
+    ),
+  );
+
+  const enrollments = enrollmentResponse?.data ?? [];
+  const enrollmentMeta = enrollmentResponse?.meta ?? {
+    limit: ENROLLMENT_PAGE_SIZE,
+    offset: enrollmentOffset,
+    count: enrollments.length,
+  };
+
+  useEffect(() => {
+    if (feedback) {
+      const timeout = setTimeout(() => setFeedback(null), 4000);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [feedback]);
+
+  useEffect(() => {
+    setEnrollmentOffset(0);
+  }, [selectedProjectId, selectedCohortId]);
+
+  const project = projects?.find((item) => item.id === selectedProjectId) ?? projects?.[0];
+  const availableCohorts = cohorts ?? [];
 
   if (session === undefined) {
     return null;
   }
 
-  const handleCreateEnrollment = () => {
-    const beneficiary = demoBeneficiaries.find((item) => item.id === selectedBeneficiaryId);
-    const cohort = availableCohorts.find((item) => item.id === selectedCohortId);
-    if (!beneficiary || !cohort || !project) {
-      alert('Selecione beneficiária, projeto e turma válidos.');
+  const handleCreateEnrollment = async () => {
+    if (!session) return;
+    if (!selectedProjectId || !selectedCohortId || !selectedBeneficiaryId) {
+      setFeedback({ type: 'error', message: 'Selecione beneficiária, projeto e turma válidos.' });
       return;
     }
 
-    setEnrollments((prev) => [
-      {
-        id: `enr-${Date.now()}`,
-        beneficiary,
-        cohort,
-        project,
-        startDate,
-        status: 'pendente',
-      },
-      ...prev,
-    ]);
+    setIsCreating(true);
+    try {
+      await createEnrollment(
+        { beneficiaryId: selectedBeneficiaryId, cohortId: selectedCohortId, enrolledAt: startDate },
+        session.token,
+      );
+      setEnrollmentOffset(0);
+      setSelectedBeneficiaryId('');
+      setFeedback({ type: 'success', message: 'Inscrição registrada com sucesso.' });
+    } catch (error) {
+      console.error(error);
+      setFeedback({ type: 'error', message: 'Não foi possível registrar a inscrição. Tente novamente.' });
+    } finally {
+      setIsCreating(false);
+    }
+  };
 
-    setSelectedBeneficiaryId('');
-    setSelectedCohortId('');
+  const handleChangePage = (offset: number) => {
+    setEnrollmentOffset(offset);
   };
 
   return (
     <Shell
       title="Inscrições em projetos"
       description="Gerencie inscrições, turmas e lista de espera das beneficiárias de forma centralizada."
-      sidebar={primarySidebar}
+      sidebar={session ? <PrimarySidebar session={session} /> : null}
     >
       <div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
         <Card className="space-y-6" padding="lg">
@@ -76,6 +181,18 @@ export default function EnrollmentsPage() {
             <p className="text-xs uppercase tracking-[0.28em] text-white/50">Nova inscrição</p>
             <h2 className="text-2xl font-semibold text-white">Configure projeto, turma e data de início</h2>
           </header>
+
+          {feedback && (
+            <div
+              className={`rounded-3xl border p-4 text-sm ${
+                feedback.type === 'success'
+                  ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-100'
+                  : 'border-rose-400/40 bg-rose-500/10 text-rose-100'
+              }`}
+            >
+              {feedback.message}
+            </div>
+          )}
 
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
@@ -90,8 +207,11 @@ export default function EnrollmentsPage() {
                   setSelectedCohortId('');
                 }}
                 className="w-full rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/80 focus:border-emerald-400 focus:outline-none"
+                disabled={loadingProjects}
               >
-                {demoProjects.map((item) => (
+                {loadingProjects && <option value="">Carregando projetos...</option>}
+                {!loadingProjects && (!projects || projects.length === 0) && <option value="">Nenhum projeto cadastrado</option>}
+                {projects?.map((item) => (
                   <option key={item.id} value={item.id}>
                     {item.name}
                   </option>
@@ -108,11 +228,13 @@ export default function EnrollmentsPage() {
                 value={selectedCohortId}
                 onChange={(event) => setSelectedCohortId(event.target.value)}
                 className="w-full rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/80 focus:border-emerald-400 focus:outline-none"
+                disabled={loadingCohorts || availableCohorts.length === 0}
               >
-                <option value="">Selecione uma turma</option>
+                {loadingCohorts && <option value="">Carregando turmas...</option>}
+                {!loadingCohorts && availableCohorts.length === 0 && <option value="">Nenhuma turma disponível</option>}
                 {availableCohorts.map((cohort) => (
                   <option key={cohort.id} value={cohort.id}>
-                    {cohort.name} • {cohort.weekday} às {cohort.time}
+                    {formatCohortLabel(cohort)}
                   </option>
                 ))}
               </select>
@@ -122,16 +244,23 @@ export default function EnrollmentsPage() {
               <label htmlFor="beneficiary" className="text-xs font-semibold uppercase tracking-[0.18em] text-white/60">
                 Beneficiária
               </label>
+              <Input
+                value={beneficiarySearch}
+                onChange={(event) => setBeneficiarySearch(event.target.value)}
+                placeholder="Buscar por nome"
+                className="text-sm"
+              />
               <select
                 id="beneficiary"
                 value={selectedBeneficiaryId}
                 onChange={(event) => setSelectedBeneficiaryId(event.target.value)}
                 className="w-full rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/80 focus:border-emerald-400 focus:outline-none"
+                disabled={loadingBeneficiaries}
               >
                 <option value="">Selecione uma beneficiária</option>
-                {demoBeneficiaries.map((beneficiary) => (
+                {beneficiaries.map((beneficiary) => (
                   <option key={beneficiary.id} value={beneficiary.id}>
-                    {beneficiary.name} • {beneficiary.status === 'aguardando' ? 'Lista de espera' : 'Ativa'}
+                    {beneficiary.fullName}
                   </option>
                 ))}
               </select>
@@ -152,29 +281,40 @@ export default function EnrollmentsPage() {
           </div>
 
           <div className="flex flex-wrap gap-3">
-            <Button type="button" onClick={handleCreateEnrollment}>
-              Registrar inscrição
+            <Button type="button" onClick={handleCreateEnrollment} disabled={isCreating}>
+              {isCreating ? 'Registrando...' : 'Registrar inscrição'}
             </Button>
-            <Button type="button" variant="secondary">
-              Integrar com API /enrollments
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => mutateEnrollments()}
+              disabled={loadingEnrollments}
+            >
+              Atualizar lista
             </Button>
           </div>
         </Card>
 
-        <ProjectOverviewCard project={project} cohorts={availableCohorts} />
+        <ProjectOverviewCard project={project} cohorts={availableCohorts} isLoading={loadingCohorts} />
       </div>
 
-      <EnrollmentTable enrollments={enrollments} />
+      <EnrollmentTable
+        enrollments={enrollments}
+        meta={enrollmentMeta}
+        isLoading={loadingEnrollments}
+        onPageChange={handleChangePage}
+      />
     </Shell>
   );
 }
 
 interface ProjectOverviewCardProps {
-  project?: DemoProject;
-  cohorts: DemoCohort[];
+  project?: ProjectRecord;
+  cohorts: CohortRecord[];
+  isLoading: boolean;
 }
 
-function ProjectOverviewCard({ project, cohorts }: ProjectOverviewCardProps) {
+function ProjectOverviewCard({ project, cohorts, isLoading }: ProjectOverviewCardProps) {
   if (!project) {
     return null;
   }
@@ -182,39 +322,48 @@ function ProjectOverviewCard({ project, cohorts }: ProjectOverviewCardProps) {
   return (
     <Card className="space-y-4" padding="lg">
       <header>
-        <p className="text-xs uppercase tracking-[0.28em] text-white/50">Capacidade do projeto</p>
+        <p className="text-xs uppercase tracking-[0.28em] text-white/50">Informações do projeto</p>
         <h3 className="mt-1 text-xl font-semibold text-white">{project.name}</h3>
-        <p className="mt-2 text-xs text-white/70">{project.description}</p>
+        {project.description && <p className="mt-2 text-xs text-white/70">{project.description}</p>}
       </header>
 
       <dl className="grid grid-cols-2 gap-4 text-sm text-white/80">
         <div>
-          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Capacidade</dt>
-          <dd className="text-lg text-white">{project.capacity}</dd>
+          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Status</dt>
+          <dd className="text-lg text-white">{project.active === false ? 'Inativo' : 'Ativo'}</dd>
         </div>
         <div>
-          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Matriculadas</dt>
-          <dd className="text-lg text-white">{project.enrolled}</dd>
+          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Slug</dt>
+          <dd>{project.slug ?? '—'}</dd>
         </div>
         <div>
-          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Lista de espera</dt>
-          <dd className="text-lg text-white">{project.waitlist}</dd>
+          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Criado em</dt>
+          <dd>{formatDate(project.createdAt)}</dd>
         </div>
         <div>
-          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Local</dt>
-          <dd>{project.location}</dd>
+          <dt className="text-xs uppercase tracking-[0.24em] text-white/40">Atualizado em</dt>
+          <dd>{formatDate(project.updatedAt)}</dd>
         </div>
       </dl>
 
       <section className="space-y-2">
         <h4 className="text-xs font-semibold uppercase tracking-[0.24em] text-white/50">Turmas disponíveis</h4>
+        {isLoading && <p className="text-xs text-white/60">Carregando turmas...</p>}
+        {!isLoading && cohorts.length === 0 && <p className="text-xs text-white/60">Nenhuma turma cadastrada.</p>}
         <ul className="space-y-2 text-xs text-white/70">
           {cohorts.map((cohort) => (
             <li key={cohort.id} className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2">
-              <p className="font-medium text-white">{cohort.name}</p>
+              <p className="font-medium text-white">{formatCohortLabel(cohort)}</p>
               <p className="text-[11px] uppercase tracking-[0.22em] text-white/40">
-                {cohort.weekday} • {cohort.time} • {cohort.educator}
+                {formatWeekday(cohort.weekday)}
+                {cohort.schedule ? ` • ${cohort.schedule}` : ''}
               </p>
+              {cohort.location && <p className="text-[11px] text-white/50">Local: {cohort.location}</p>}
+              {cohort.educators && cohort.educators.length > 0 && (
+                <p className="text-[11px] text-white/50">
+                  Educadoras: {cohort.educators.map((item) => item.name ?? 'Equipe IMM').join(', ')}
+                </p>
+              )}
             </li>
           ))}
         </ul>
@@ -224,31 +373,64 @@ function ProjectOverviewCard({ project, cohorts }: ProjectOverviewCardProps) {
 }
 
 interface EnrollmentTableProps {
-  enrollments: LocalEnrollment[];
+  enrollments: EnrollmentRecord[];
+  meta: PaginationMeta;
+  isLoading: boolean;
+  onPageChange: (offset: number) => void;
 }
 
-function EnrollmentTable({ enrollments }: EnrollmentTableProps) {
+function EnrollmentTable({ enrollments, meta, isLoading, onPageChange }: EnrollmentTableProps) {
+  if (isLoading) {
+    return (
+      <Card className="space-y-3" padding="lg">
+        <h3 className="text-lg font-semibold text-white">Inscrições recentes</h3>
+        <p className="text-sm text-white/70">Carregando registros de inscrições...</p>
+      </Card>
+    );
+  }
+
   if (enrollments.length === 0) {
     return (
       <Card className="space-y-3" padding="lg">
-        <h3 className="text-lg font-semibold text-white">Nenhuma inscrição recente</h3>
+        <h3 className="text-lg font-semibold text-white">Nenhuma inscrição encontrada</h3>
         <p className="text-sm text-white/70">
-          Use o formulário acima para registrar novas inscrições e acompanhar o status de aprovação com a coordenação.
+          Utilize o formulário acima para registrar novas inscrições ou ajuste os filtros selecionados.
         </p>
       </Card>
     );
   }
+
+  const canPrevious = meta.offset > 0;
+  const canNext = meta.offset + meta.limit < meta.count;
 
   return (
     <Card className="overflow-hidden" padding="lg">
       <div className="flex items-center justify-between">
         <div>
           <p className="text-xs uppercase tracking-[0.28em] text-white/50">Histórico</p>
-          <h3 className="text-xl font-semibold text-white">Inscrições registradas nesta sessão</h3>
+          <h3 className="text-xl font-semibold text-white">Inscrições registradas</h3>
+          <p className="text-xs text-white/60">
+            Mostrando {Math.min(meta.offset + meta.limit, meta.count)} de {meta.count} registros
+          </p>
         </div>
-        <Button type="button" variant="secondary">
-          Exportar para planilha
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!canPrevious}
+            onClick={() => onPageChange(Math.max(0, meta.offset - meta.limit))}
+          >
+            Página anterior
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!canNext}
+            onClick={() => onPageChange(meta.offset + meta.limit)}
+          >
+            Próxima página
+          </Button>
+        </div>
       </div>
 
       <div className="mt-4 overflow-x-auto">
@@ -265,12 +447,15 @@ function EnrollmentTable({ enrollments }: EnrollmentTableProps) {
           <tbody className="divide-y divide-white/5">
             {enrollments.map((enrollment) => (
               <tr key={enrollment.id} className="bg-white/0">
-                <td className="px-4 py-3 text-white">{enrollment.beneficiary.name}</td>
-                <td className="px-4 py-3">{enrollment.project.name}</td>
-                <td className="px-4 py-3">
-                  {enrollment.cohort.name} • {enrollment.cohort.weekday}
+                <td className="px-4 py-3 text-white">
+                  <div className="font-medium">{enrollment.beneficiaryName ?? enrollment.beneficiaryId}</div>
+                  <div className="text-xs text-white/50">ID: {enrollment.beneficiaryId}</div>
                 </td>
-                <td className="px-4 py-3">{enrollment.startDate}</td>
+                <td className="px-4 py-3">{enrollment.projectName ?? '—'}</td>
+                <td className="px-4 py-3">
+                  {enrollment.cohortCode ? `Turma ${enrollment.cohortCode}` : enrollment.cohortId}
+                </td>
+                <td className="px-4 py-3">{formatDate(enrollment.enrolledAt ?? enrollment.startDate)}</td>
                 <td className="px-4 py-3">
                   <StatusPill status={enrollment.status} />
                 </td>
@@ -283,21 +468,62 @@ function EnrollmentTable({ enrollments }: EnrollmentTableProps) {
   );
 }
 
-function StatusPill({ status }: { status: LocalEnrollment['status'] }) {
-  const labelMap: Record<LocalEnrollment['status'], string> = {
-    ativa: 'Ativa',
-    aguardando: 'Lista de espera',
-    pendente: 'Pendente de aprovação',
-  };
-  const colorMap: Record<LocalEnrollment['status'], string> = {
-    ativa: 'bg-emerald-500/20 text-emerald-100 border-emerald-400/40',
-    aguardando: 'bg-amber-500/15 text-amber-100 border-amber-400/30',
-    pendente: 'bg-cyan-500/15 text-cyan-100 border-cyan-400/30',
+function StatusPill({ status }: { status: string }) {
+  const normalized = status.toLowerCase();
+  const config = ENROLLMENT_STATUS_LABELS[normalized] ?? {
+    label: status,
+    className: 'bg-white/10 text-white/70 border-white/20',
   };
 
   return (
-    <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${colorMap[status]}`}>
-      {labelMap[status]}
+    <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${config.className}`}>
+      {config.label}
     </span>
   );
+}
+
+type EnrollmentListResponse = { data: EnrollmentRecord[]; meta: PaginationMeta };
+
+function formatDate(value?: string | null) {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleDateString('pt-BR');
+  } catch (error) {
+    console.error(error);
+    return value;
+  }
+}
+
+function formatWeekday(value?: number | null) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  const labels = [
+    'Domingo',
+    'Segunda-feira',
+    'Terça-feira',
+    'Quarta-feira',
+    'Quinta-feira',
+    'Sexta-feira',
+    'Sábado',
+  ];
+  const index = value >= 1 && value <= 7 ? value - 1 : value;
+  return labels[index] ?? '—';
+}
+
+function formatCohortLabel(cohort: CohortRecord) {
+  const labelParts: string[] = [];
+  if (cohort.code) {
+    labelParts.push(`Turma ${cohort.code}`);
+  }
+  if (cohort.shift) {
+    labelParts.push(cohort.shift);
+  }
+  if (cohort.startTime && cohort.endTime) {
+    labelParts.push(`${cohort.startTime} - ${cohort.endTime}`);
+  }
+  if (labelParts.length === 0) {
+    labelParts.push('Turma');
+  }
+  return labelParts.join(' • ');
 }

--- a/apps/dashboard/lib/api.ts
+++ b/apps/dashboard/lib/api.ts
@@ -33,6 +33,34 @@ export async function fetchJson(path: string, params: Record<string, unknown> = 
   return response.text();
 }
 
+export async function requestJson(
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  } = {},
+  token?: string | null,
+) {
+  const url = `${API_URL}${path}`;
+  const body: BodyInit | undefined = (() => {
+    if (options.body === undefined) {
+      return undefined;
+    }
+    if (typeof options.body === 'string') {
+      return options.body;
+    }
+    return JSON.stringify(options.body);
+  })();
+  const response = await fetch(url, {
+    method: options.method ?? 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(options.headers ?? {}),
+    },
+    credentials: 'include',
+    body,
   });
 
   if (!response.ok) {
@@ -68,4 +96,15 @@ export async function downloadFile(path: string, params: Record<string, unknown>
   anchor.download = filename;
   anchor.click();
   URL.revokeObjectURL(objectUrl);
+}
+
+export function postJson(path: string, body: unknown, token?: string | null) {
+  return requestJson(
+    path,
+    {
+      method: 'POST',
+      body,
+    },
+    token,
+  );
 }

--- a/apps/dashboard/tests/ActionPlansPage.test.tsx
+++ b/apps/dashboard/tests/ActionPlansPage.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import ActionPlansPage from '../app/action-plans/page';
+
+const swrDataMap = new Map<string, unknown>();
+const swrMutateMap = new Map<string, ReturnType<typeof vi.fn>>();
+
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (key: any) => {
+    if (!key) {
+      return { data: undefined, error: undefined, isLoading: false, mutate: vi.fn() };
+    }
+    const mapKey = Array.isArray(key) ? key[0] : key;
+    const data = swrDataMap.get(mapKey);
+    const mutate = swrMutateMap.get(mapKey) ?? vi.fn();
+    swrMutateMap.set(mapKey, mutate);
+    return { data, error: undefined, isLoading: false, mutate };
+  },
+}));
+
+vi.mock('../hooks/useRequirePermission', () => ({
+  useRequirePermission: vi.fn(() => ({
+    token: 'token',
+    refreshToken: 'refresh',
+    refreshTokenExpiresAt: '2024-01-01T00:00:00.000Z',
+    permissions: ['action_plans:read', 'action_plans:update', 'action_plans:create'],
+    roles: ['admin'],
+    projectScopes: [],
+    user: { id: '1', name: 'Admin', email: 'admin@example.com' },
+  })),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+}));
+
+const { createActionPlanMock, createActionPlanItemMock, updateActionPlanItemMock } = vi.hoisted(() => ({
+  createActionPlanMock: vi.fn(),
+  createActionPlanItemMock: vi.fn(),
+  updateActionPlanItemMock: vi.fn(),
+}));
+
+vi.mock('../lib/operations', async () => {
+  const actual = await vi.importActual<typeof import('../lib/operations')>('../lib/operations');
+  return {
+    ...actual,
+    createActionPlan: createActionPlanMock,
+    createActionPlanItem: createActionPlanItemMock,
+    updateActionPlanItem: updateActionPlanItemMock,
+  };
+});
+
+describe('ActionPlansPage', () => {
+  beforeEach(() => {
+    swrDataMap.clear();
+    swrMutateMap.clear();
+    createActionPlanMock.mockResolvedValue({});
+    createActionPlanItemMock.mockResolvedValue({});
+    updateActionPlanItemMock.mockResolvedValue({});
+
+    swrDataMap.set('beneficiaries:list', {
+      data: [
+        {
+          id: 'b1',
+          code: '001',
+          fullName: 'Ana Silva',
+          birthDate: null,
+          cpf: null,
+          phone1: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          vulnerabilities: [],
+        },
+      ],
+      meta: { limit: 50, offset: 0, count: 1 },
+    });
+
+    swrDataMap.set('action-plans:list', [
+      {
+        id: 'plan1',
+        beneficiaryId: 'b1',
+        status: 'active',
+        createdBy: null,
+        createdAt: '2024-01-10T00:00:00.000Z',
+        updatedAt: '2024-01-12T00:00:00.000Z',
+        items: [
+          {
+            id: 'task1',
+            actionPlanId: 'plan1',
+            title: 'Atualizar currículo',
+            responsible: 'Equipe IMM',
+            dueDate: '2024-06-01',
+            status: 'pending',
+            support: null,
+            notes: null,
+            completedAt: null,
+            createdAt: '2024-01-10T00:00:00.000Z',
+            updatedAt: '2024-01-10T00:00:00.000Z',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('renders plan data and updates task status', () => {
+    render(<ActionPlansPage />);
+
+    expect(screen.getByText('Ana Silva')).toBeInTheDocument();
+    expect(screen.getByText('Atualizar currículo')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Em andamento' }));
+    expect(updateActionPlanItemMock).toHaveBeenCalledWith(
+      'plan1',
+      'task1',
+      { status: 'in_progress', completedAt: null },
+      'token',
+    );
+  });
+
+  it('allows creating a new action item', () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Nova ação');
+    render(<ActionPlansPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Adicionar ação' }));
+
+    expect(createActionPlanItemMock).toHaveBeenCalledWith(
+      'plan1',
+      expect.objectContaining({ title: 'Nova ação', status: 'pending' }),
+      'token',
+    );
+
+    promptSpy.mockRestore();
+  });
+});

--- a/apps/dashboard/tests/EnrollmentsPage.test.tsx
+++ b/apps/dashboard/tests/EnrollmentsPage.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import EnrollmentsPage from '../app/enrollments/page';
+
+const swrDataMap = new Map<string, unknown>();
+const swrMutateMap = new Map<string, ReturnType<typeof vi.fn>>();
+
+vi.mock('swr', () => ({
+  __esModule: true,
+  default: (key: any) => {
+    if (!key) {
+      return { data: undefined, error: undefined, isLoading: false, mutate: vi.fn() };
+    }
+    const mapKey = Array.isArray(key) ? key[0] : key;
+    const data = swrDataMap.get(mapKey);
+    const mutate = swrMutateMap.get(mapKey) ?? vi.fn();
+    swrMutateMap.set(mapKey, mutate);
+    return { data, error: undefined, isLoading: false, mutate };
+  },
+}));
+
+vi.mock('../hooks/useRequirePermission', () => ({
+  useRequirePermission: vi.fn(() => ({
+    token: 'token',
+    refreshToken: 'refresh',
+    refreshTokenExpiresAt: '2024-01-01T00:00:00.000Z',
+    permissions: ['enrollments:create:project', 'enrollments:read:project'],
+    roles: ['admin'],
+    projectScopes: [],
+    user: { id: '1', name: 'Admin', email: 'admin@example.com' },
+  })),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+}));
+
+const { createEnrollmentMock } = vi.hoisted(() => ({
+  createEnrollmentMock: vi.fn(),
+}));
+
+vi.mock('../lib/operations', async () => {
+  const actual = await vi.importActual<typeof import('../lib/operations')>('../lib/operations');
+  return {
+    ...actual,
+    createEnrollment: createEnrollmentMock,
+  };
+});
+
+describe('EnrollmentsPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-01T12:00:00Z'));
+    swrDataMap.clear();
+    swrMutateMap.clear();
+    createEnrollmentMock.mockResolvedValue({});
+
+    swrDataMap.set('projects:list', [
+      {
+        id: 'p1',
+        name: 'Projeto Imersão',
+        description: 'Formação profissional',
+        focus: null,
+        status: 'ativo',
+        capacity: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+        slug: 'imersao',
+        active: true,
+      },
+    ]);
+
+    swrDataMap.set('projects:cohorts', [
+      {
+        id: 'c1',
+        projectId: 'p1',
+        code: 'A',
+        shift: 'Manhã',
+        startTime: '08:00',
+        endTime: '10:00',
+        capacity: 15,
+        location: 'Sala 1',
+        educators: [{ id: 'u1', name: 'Maria' }],
+      },
+    ]);
+
+    swrDataMap.set('beneficiaries:list', {
+      data: [
+        {
+          id: 'b1',
+          code: '001',
+          fullName: 'Ana Clara',
+          birthDate: '1995-01-01',
+          cpf: null,
+          phone1: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          vulnerabilities: [],
+        },
+      ],
+      meta: { limit: 50, offset: 0, count: 1 },
+    });
+
+    swrDataMap.set('enrollments:list', {
+      data: [
+        {
+          id: 'en1',
+          beneficiaryId: 'b1',
+          beneficiaryName: 'Ana Clara',
+          cohortId: 'c1',
+          cohortCode: 'A',
+          status: 'active',
+          startDate: '2024-01-10',
+          endDate: null,
+          disengagementReason: null,
+          agreementsAccepted: true,
+          createdAt: '2024-01-10T00:00:00.000Z',
+          updatedAt: '2024-01-10T00:00:00.000Z',
+          projectId: 'p1',
+          projectName: 'Projeto Imersão',
+          enrolledAt: '2024-01-10',
+        },
+      ],
+      meta: { limit: 10, offset: 0, count: 1 },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders API data and allows creating a new enrollment', () => {
+    render(<EnrollmentsPage />);
+
+    expect(screen.getAllByText('Projeto Imersão').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Turma A • Manhã • 08:00 - 10:00').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Ana Clara').length).toBeGreaterThan(0);
+    expect(screen.getByText('Inscrições registradas')).toBeInTheDocument();
+    expect(screen.getByText('Turma A')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Beneficiária'), { target: { value: 'b1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Registrar inscrição' }));
+
+    expect(createEnrollmentMock).toHaveBeenCalledWith(
+      { beneficiaryId: 'b1', cohortId: 'c1', enrolledAt: '2024-05-01' },
+      'token',
+    );
+  });
+});

--- a/apps/dashboard/tests/mocks/msw.ts
+++ b/apps/dashboard/tests/mocks/msw.ts
@@ -1,0 +1,107 @@
+import { vi } from 'vitest';
+
+type ResponseLike = Response | { status?: number; headers?: Record<string, string>; body?: BodyInit | null };
+
+type ResolverArgs = {
+  params: Record<string, string>;
+  request: Request;
+};
+
+type Handler = {
+  method: string;
+  matcher: RegExp;
+  paramNames: string[];
+  resolver: (args: ResolverArgs) => ResponseLike | Promise<ResponseLike>;
+};
+
+function toRegExp(path: string) {
+  const paramNames: string[] = [];
+  const escaped = path.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const pattern = escaped.replace(/:(\w+)/g, (_, name) => {
+    paramNames.push(name);
+    return '([^/]+)';
+  });
+  return { matcher: new RegExp(`^${pattern}$`), paramNames };
+}
+
+function createHandler(method: string, path: string, resolver: Handler['resolver']): Handler {
+  const { matcher, paramNames } = toRegExp(path);
+  return { method: method.toUpperCase(), matcher, paramNames, resolver };
+}
+
+export const http = {
+  get: (path: string, resolver: Handler['resolver']) => createHandler('GET', path, resolver),
+  post: (path: string, resolver: Handler['resolver']) => createHandler('POST', path, resolver),
+  put: (path: string, resolver: Handler['resolver']) => createHandler('PUT', path, resolver),
+  patch: (path: string, resolver: Handler['resolver']) => createHandler('PATCH', path, resolver),
+  delete: (path: string, resolver: Handler['resolver']) => createHandler('DELETE', path, resolver),
+};
+
+export const HttpResponse = {
+  json(data: unknown, init: { status?: number; headers?: Record<string, string> } = {}) {
+    return {
+      status: init.status ?? 200,
+      headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+      body: JSON.stringify(data),
+    } as ResponseLike;
+  },
+};
+
+export function setupServer(...initialHandlers: Handler[]) {
+  const handlers = [...initialHandlers];
+  let defaultHandlers = [...initialHandlers];
+  let originalFetch: typeof fetch | null = null;
+
+  async function dispatchFetch(input: RequestInfo | URL, init?: RequestInit) {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const method = request.method.toUpperCase();
+    const url = request.url;
+
+    for (const handler of handlers) {
+      if (handler.method !== method) continue;
+      const match = handler.matcher.exec(url);
+      if (!match) continue;
+      const params: Record<string, string> = {};
+      handler.paramNames.forEach((name, index) => {
+        params[name] = decodeURIComponent(match[index + 1] ?? '');
+      });
+      const result = await handler.resolver({ params, request });
+      if (result instanceof Response) {
+        return result;
+      }
+      const { status = 200, headers = {}, body = null } = result ?? {};
+      return new Response(body, { status, headers });
+    }
+
+    if (originalFetch) {
+      return originalFetch(input, init);
+    }
+
+    throw new Error(`Unhandled request: ${method} ${url}`);
+  }
+
+  return {
+    listen: (_options?: { onUnhandledRequest?: 'error' | 'bypass' | ((req: Request) => void) }) => {
+      if (!originalFetch) {
+        originalFetch = global.fetch;
+        global.fetch = dispatchFetch as typeof fetch;
+      }
+    },
+    close: () => {
+      if (originalFetch) {
+        global.fetch = originalFetch;
+        originalFetch = null;
+      }
+    },
+    resetHandlers: (...next: Handler[]) => {
+      if (next.length > 0) {
+        handlers.splice(0, handlers.length, ...next);
+      } else {
+        handlers.splice(0, handlers.length, ...defaultHandlers);
+      }
+    },
+    use: (...next: Handler[]) => {
+      handlers.push(...next);
+    },
+  };
+}

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -5,5 +6,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      'msw/node': path.resolve(__dirname, 'tests/mocks/msw.ts'),
+      msw: path.resolve(__dirname, 'tests/mocks/msw.ts'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- replace demo data on enrollments and action plans pages with operations.ts API calls and live pagination
- add backend-aware enrollment and action plan handlers plus feedback states and API helpers
- introduce MSW shim, Vitest aliases, and new UI integration tests mocking operations.ts

## Testing
- pnpm --filter imm-dashboard test -- tests/EnrollmentsPage.test.tsx tests/ActionPlansPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d6994923a08324b73f5c0dcd311deb