### PR TITLE
Fix attachments service logger import path

### DIFF
--- a/src/modules/attachments/service.ts
+++ b/src/modules/attachments/service.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import { env } from '../../config/env';
-import { logger } from '../../observability/logger';
+import { logger } from '../../config/logger';
 import { attachmentsRepository } from './repository';
 import { antivirusScanner } from './antivirus';
 import { storageProvider } from './storage';


### PR DESCRIPTION
## Summary
- fix the attachments service to import the logger from the config module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a2e633008324abbab4974e883ce6