### PR TITLE
feat: align initial schema with beneficiary-centric tables

### DIFF
--- a/artifacts/sql/0001_initial.sql
+++ b/artifacts/sql/0001_initial.sql
@@ -1,325 +1,403 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
--- Usuários e perfis
+-- Users and access control ---------------------------------------------------
 CREATE TABLE users (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name TEXT NOT NULL,
   email TEXT NOT NULL UNIQUE,
   password_hash TEXT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE TABLE profiles (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID NOT NULL REFERENCES users(id),
-  type TEXT NOT NULL,
-  data JSONB NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+CREATE TABLE roles (
+  id SERIAL PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX profiles_user_id_idx ON profiles(user_id);
-
--- Projetos e turmas
 CREATE TABLE projects (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT UNIQUE,
   name TEXT NOT NULL,
   description TEXT,
   status TEXT NOT NULL DEFAULT 'active',
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE user_roles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  project_id UUID REFERENCES projects(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, role_id, project_id)
+);
+
+CREATE INDEX idx_user_roles_user ON user_roles(user_id);
+CREATE INDEX idx_user_roles_role ON user_roles(role_id);
+CREATE INDEX idx_user_roles_project ON user_roles(project_id);
+
+-- Beneficiaries and household context ---------------------------------------
+CREATE TABLE beneficiaries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT UNIQUE,
+  full_name TEXT NOT NULL,
+  birth_date DATE,
+  cpf TEXT,
+  rg TEXT,
+  rg_issuer TEXT,
+  rg_issue_date DATE,
+  nis TEXT,
+  phone1 TEXT,
+  phone2 TEXT,
+  email TEXT,
+  address TEXT,
+  neighborhood TEXT,
+  city TEXT,
+  state TEXT,
+  reference TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_beneficiaries_full_name ON beneficiaries USING gin (to_tsvector('portuguese', coalesce(full_name, '')));
+CREATE INDEX idx_beneficiaries_created_at ON beneficiaries(created_at DESC);
+
+CREATE TABLE household_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  name TEXT,
+  birth_date DATE,
+  works BOOLEAN,
+  income NUMERIC(12,2),
+  schooling TEXT,
+  relationship TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_household_members_beneficiary ON household_members(beneficiary_id);
+
+CREATE TABLE vulnerabilities (
+  id SERIAL PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  label TEXT,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE beneficiary_vulnerabilities (
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  vulnerability_id INTEGER NOT NULL REFERENCES vulnerabilities(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (beneficiary_id, vulnerability_id)
+);
+
+-- Projects, cohorts and enrollments -----------------------------------------
 CREATE TABLE cohorts (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  project_id UUID NOT NULL REFERENCES projects(id),
-  name TEXT NOT NULL,
-  start_date DATE NOT NULL,
-  end_date DATE,
-  status TEXT NOT NULL DEFAULT 'active',
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  code TEXT,
+  weekday SMALLINT,
+  shift TEXT,
+  start_time TIME,
+  end_time TIME,
+  capacity INTEGER,
+  location TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX cohorts_project_id_idx ON cohorts(project_id);
+CREATE INDEX idx_cohorts_project ON cohorts(project_id);
+CREATE INDEX idx_cohorts_code ON cohorts(code);
 
--- Formulários e submissões
-CREATE TABLE forms (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  title TEXT NOT NULL,
-  description TEXT,
+CREATE TABLE cohort_educators (
+  cohort_id UUID NOT NULL REFERENCES cohorts(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (cohort_id, user_id)
+);
+
+CREATE INDEX idx_cohort_educators_user ON cohort_educators(user_id);
+
+CREATE TABLE enrollments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  cohort_id UUID NOT NULL REFERENCES cohorts(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'active',
+  enrolled_at DATE NOT NULL DEFAULT current_date,
+  terminated_at DATE,
+  termination_reason TEXT,
+  agreement_acceptance JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (beneficiary_id, cohort_id, enrolled_at)
+);
+
+CREATE INDEX idx_enrollments_beneficiary ON enrollments(beneficiary_id);
+CREATE INDEX idx_enrollments_cohort ON enrollments(cohort_id);
+CREATE INDEX idx_enrollments_status ON enrollments(status);
+
+CREATE UNIQUE INDEX uq_enrollments_active ON enrollments(beneficiary_id, cohort_id)
+  WHERE status = 'active';
+
+CREATE TABLE attendance (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  enrollment_id UUID NOT NULL REFERENCES enrollments(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  present BOOLEAN NOT NULL,
+  justification TEXT,
+  recorded_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (enrollment_id, date)
+);
+
+CREATE INDEX idx_attendance_enrollment ON attendance(enrollment_id);
+CREATE INDEX idx_attendance_date ON attendance(date);
+
+-- Forms and submissions ------------------------------------------------------
+CREATE TABLE form_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  form_type TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
   schema JSONB NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  version INTEGER NOT NULL DEFAULT 1,
-  status TEXT NOT NULL DEFAULT 'active'
+  status TEXT NOT NULL DEFAULT 'draft',
+  published_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (form_type, schema_version)
+);
+
+CREATE TABLE form_template_revisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id UUID NOT NULL REFERENCES form_templates(id) ON DELETE CASCADE,
+  form_type TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  schema JSONB NOT NULL,
+  status TEXT NOT NULL,
+  published_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  UNIQUE (template_id, revision)
 );
 
 CREATE TABLE form_submissions (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  form_id UUID NOT NULL REFERENCES forms(id),
-  profile_id UUID NOT NULL REFERENCES profiles(id),
-  data JSONB NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  version INTEGER NOT NULL,
-  status TEXT NOT NULL DEFAULT 'submitted'
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  form_type TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  signed_by TEXT[],
+  signed_at TIMESTAMPTZ[],
+  attachments JSONB,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX form_submissions_form_id_idx ON form_submissions(form_id);
-CREATE INDEX form_submissions_profile_id_idx ON form_submissions(profile_id);
+CREATE INDEX idx_form_submissions_beneficiary ON form_submissions(beneficiary_id);
+CREATE INDEX idx_form_submissions_type ON form_submissions(form_type);
 
--- Consentimentos
+-- Consents and audit ---------------------------------------------------------
 CREATE TABLE consents (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  profile_id UUID NOT NULL REFERENCES profiles(id),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
   type TEXT NOT NULL,
+  text_version TEXT NOT NULL,
   granted BOOLEAN NOT NULL,
-  data JSONB,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  evidence JSONB,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX consents_profile_id_idx ON consents(profile_id);
+CREATE INDEX idx_consents_beneficiary ON consents(beneficiary_id);
+CREATE INDEX idx_consents_type ON consents(type);
+CREATE INDEX idx_consents_status ON consents(beneficiary_id, type, granted)
+  WHERE revoked_at IS NULL;
 
--- Registros de auditoria
 CREATE TABLE audit_logs (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID REFERENCES users(id),
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  entity TEXT NOT NULL,
+  entity_id UUID NOT NULL,
   action TEXT NOT NULL,
-  resource_type TEXT NOT NULL,
-  resource_id UUID,
-  metadata JSONB,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  before_data JSONB,
+  after_data JSONB,
+  justification TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX audit_logs_user_id_idx ON audit_logs(user_id);
-CREATE INDEX audit_logs_resource_type_id_idx ON audit_logs(resource_type, resource_id);
+CREATE INDEX idx_audit_logs_user ON audit_logs(user_id);
+CREATE INDEX idx_audit_logs_entity ON audit_logs(entity, entity_id);
 
--- Notificações
-CREATE TABLE notifications (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID REFERENCES users(id),
-  type TEXT NOT NULL,
-  title TEXT NOT NULL,
-  content TEXT NOT NULL,
-  metadata JSONB,
-  read_at TIMESTAMPTZ,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX notifications_user_id_idx ON notifications(user_id);
-
--- Anexos
+-- Attachments ----------------------------------------------------------------
 CREATE TABLE attachments (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   filename TEXT NOT NULL,
   mimetype TEXT NOT NULL,
   key TEXT NOT NULL UNIQUE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   scanned_at TIMESTAMPTZ,
   is_infected BOOLEAN,
   virus_names TEXT[]
 );
 
--- Feed institucional
-CREATE TABLE feed_posts (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  author_id UUID NOT NULL REFERENCES users(id),
-  title TEXT NOT NULL,
-  content TEXT NOT NULL,
-  metadata JSONB,
-  published_at TIMESTAMPTZ,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+-- Messaging ------------------------------------------------------------------
+CREATE TABLE threads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope TEXT NOT NULL,
+  subject TEXT,
+  visibility TEXT NOT NULL DEFAULT 'internal',
+  classification TEXT NOT NULL DEFAULT 'publico_interno',
+  retention_expires_at TIMESTAMPTZ,
+  search_terms TEXT[] DEFAULT '{}',
+  created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX feed_posts_author_id_idx ON feed_posts(author_id);
-CREATE INDEX feed_posts_published_at_idx ON feed_posts(published_at);
+CREATE INDEX idx_threads_scope ON threads(scope);
+CREATE INDEX idx_threads_created_by ON threads(created_by);
 
--- Central de mensagens
-CREATE TABLE message_threads (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  title TEXT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE message_thread_participants (
-  thread_id UUID NOT NULL REFERENCES message_threads(id),
-  user_id UUID NOT NULL REFERENCES users(id),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+CREATE TABLE thread_members (
+  thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (thread_id, user_id)
 );
 
+CREATE INDEX idx_thread_members_user ON thread_members(user_id);
+
 CREATE TABLE messages (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  thread_id UUID NOT NULL REFERENCES message_threads(id),
-  sender_id UUID NOT NULL REFERENCES users(id),
-  content TEXT NOT NULL,
-  metadata JSONB,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id UUID NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  visibility TEXT NOT NULL DEFAULT 'internal',
+  is_confidential BOOLEAN NOT NULL DEFAULT FALSE,
+  classification TEXT NOT NULL DEFAULT 'publico_interno',
+  retention_expires_at TIMESTAMPTZ,
+  mentions TEXT[] DEFAULT '{}',
+  attachment_ids UUID[] DEFAULT '{}',
+  search_terms TEXT[] DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX messages_thread_id_idx ON messages(thread_id);
-CREATE INDEX messages_sender_id_idx ON messages(sender_id);
+CREATE INDEX idx_messages_thread ON messages(thread_id, created_at DESC);
+CREATE INDEX idx_messages_author ON messages(author_id);
 
--- Inscrições e planos de ação
-CREATE TABLE enrollments (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  cohort_id UUID NOT NULL REFERENCES cohorts(id),
-  profile_id UUID NOT NULL REFERENCES profiles(id),
-  status TEXT NOT NULL DEFAULT 'pending',
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (cohort_id, profile_id)
+-- Institutional feed ---------------------------------------------------------
+CREATE TABLE posts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID REFERENCES projects(id) ON DELETE SET NULL,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT,
+  body TEXT,
+  tags TEXT[],
+  visibility TEXT NOT NULL DEFAULT 'internal',
+  published_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX enrollments_cohort_id_idx ON enrollments(cohort_id);
-CREATE INDEX enrollments_profile_id_idx ON enrollments(profile_id);
+CREATE INDEX idx_posts_project ON posts(project_id);
+CREATE INDEX idx_posts_published_at ON posts(published_at DESC NULLS LAST);
 
+CREATE TABLE comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_comments_post ON comments(post_id);
+CREATE INDEX idx_comments_author ON comments(author_id);
+
+CREATE TABLE post_reactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (post_id, author_id)
+);
+
+CREATE INDEX idx_post_reactions_post ON post_reactions(post_id);
+CREATE INDEX idx_post_reactions_author ON post_reactions(author_id);
+
+-- Action plans and evolutions ------------------------------------------------
 CREATE TABLE action_plans (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  enrollment_id UUID NOT NULL REFERENCES enrollments(id),
-  created_by UUID NOT NULL REFERENCES users(id),
-  title TEXT NOT NULL,
-  description TEXT,
-  status TEXT NOT NULL DEFAULT 'draft',
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX action_plans_enrollment_id_idx ON action_plans(enrollment_id);
+CREATE INDEX idx_action_plans_beneficiary ON action_plans(beneficiary_id);
 
 CREATE TABLE action_items (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  plan_id UUID NOT NULL REFERENCES action_plans(id),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  action_plan_id UUID NOT NULL REFERENCES action_plans(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
-  description TEXT,
+  responsible TEXT,
   due_date DATE,
   status TEXT NOT NULL DEFAULT 'pending',
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  support TEXT,
+  notes TEXT,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX action_items_plan_id_idx ON action_items(plan_id);
+CREATE INDEX idx_action_items_plan ON action_items(action_plan_id);
+CREATE INDEX idx_action_items_status ON action_items(status);
 
--- Certificados
+CREATE TABLE evolutions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  description TEXT NOT NULL,
+  category TEXT,
+  responsible TEXT,
+  requires_signature BOOLEAN NOT NULL DEFAULT FALSE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_evolutions_beneficiary ON evolutions(beneficiary_id, date DESC);
+
+-- Certificates ---------------------------------------------------------------
 CREATE TABLE certificates (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  enrollment_id UUID NOT NULL REFERENCES enrollments(id),
-  type TEXT NOT NULL,
-  issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  enrollment_id UUID NOT NULL REFERENCES enrollments(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT 'completion',
+  issued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  issued_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  total_sessions INTEGER NOT NULL DEFAULT 0,
+  present_sessions INTEGER NOT NULL DEFAULT 0,
+  attendance_rate NUMERIC(5,4),
+  file_path TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  mime_type TEXT NOT NULL DEFAULT 'application/pdf',
   metadata JSONB,
-  UNIQUE (enrollment_id, type)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX certificates_enrollment_id_idx ON certificates(enrollment_id);
-
--- Funções e permissões
-CREATE TABLE roles (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  name TEXT NOT NULL UNIQUE,
-  description TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE permissions (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  name TEXT NOT NULL UNIQUE,
-  description TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
-CREATE TABLE role_permissions (
-  role_id UUID NOT NULL REFERENCES roles(id),
-  permission_id UUID NOT NULL REFERENCES permissions(id),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  PRIMARY KEY (role_id, permission_id)
-);
-
-CREATE TABLE user_roles (
-  user_id UUID NOT NULL REFERENCES users(id),
-  role_id UUID NOT NULL REFERENCES roles(id),
-  project_id UUID REFERENCES projects(id),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  PRIMARY KEY (user_id, role_id, project_id)
-);
-
-CREATE INDEX user_roles_project_id_idx ON user_roles(project_id);
-
--- Views para análise
-CREATE VIEW enrollments_overview AS
-SELECT
-  e.id AS enrollment_id,
-  e.status AS enrollment_status,
-  e.created_at AS enrollment_date,
-  c.id AS cohort_id,
-  c.name AS cohort_name,
-  p.id AS project_id,
-  p.name AS project_name,
-  pr.id AS profile_id,
-  u.id AS user_id,
-  u.name AS user_name,
-  u.email AS user_email
-FROM enrollments e
-JOIN cohorts c ON e.cohort_id = c.id
-JOIN projects p ON c.project_id = p.id
-JOIN profiles pr ON e.profile_id = pr.id
-JOIN users u ON pr.user_id = u.id;
-
-CREATE VIEW action_plans_overview AS
-SELECT
-  ap.id AS plan_id,
-  ap.title AS plan_title,
-  ap.status AS plan_status,
-  ap.created_at AS plan_created_at,
-  e.id AS enrollment_id,
-  c.id AS cohort_id,
-  c.name AS cohort_name,
-  p.id AS project_id,
-  p.name AS project_name,
-  pr.id AS profile_id,
-  u.id AS user_id,
-  u.name AS user_name,
-  u.email AS user_email,
-  COUNT(ai.id) AS total_items,
-  SUM(CASE WHEN ai.status = 'completed' THEN 1 ELSE 0 END) AS completed_items
-FROM action_plans ap
-JOIN enrollments e ON ap.enrollment_id = e.id
-JOIN cohorts c ON e.cohort_id = c.id
-JOIN projects p ON c.project_id = p.id
-JOIN profiles pr ON e.profile_id = pr.id
-JOIN users u ON pr.user_id = u.id
-LEFT JOIN action_items ai ON ap.id = ai.plan_id
-GROUP BY
-  ap.id, ap.title, ap.status, ap.created_at,
-  e.id, c.id, c.name, p.id, p.name,
-  pr.id, u.id, u.name, u.email;
-
-CREATE VIEW certificates_overview AS
-SELECT
-  cert.id AS certificate_id,
-  cert.type AS certificate_type,
-  cert.issued_at AS certificate_issued_at,
-  e.id AS enrollment_id,
-  e.status AS enrollment_status,
-  c.id AS cohort_id,
-  c.name AS cohort_name,
-  p.id AS project_id,
-  p.name AS project_name,
-  pr.id AS profile_id,
-  u.id AS user_id,
-  u.name AS user_name,
-  u.email AS user_email
-FROM certificates cert
-JOIN enrollments e ON cert.enrollment_id = e.id
-JOIN cohorts c ON e.cohort_id = c.id
-JOIN projects p ON c.project_id = p.id
-JOIN profiles pr ON e.profile_id = pr.id
-JOIN users u ON pr.user_id = u.id;
-
+CREATE INDEX idx_certificates_enrollment ON certificates(enrollment_id);
+CREATE INDEX idx_certificates_issued_at ON certificates(issued_at DESC);


### PR DESCRIPTION
## Summary
- rebuild the base migration with user, role, and project tables compatible with the current RBAC implementation
- define beneficiary-centric structures (beneficiaries, household members, vulnerabilities, enrollments, attendance) and enrich cohorts with reporting metadata
- include form, consent, messaging, feed, action plan, evolution, attachment, and certificate tables plus supporting indexes needed by analytics views

## Testing
- npm test *(fails: repository contains unresolved merge markers in tests and an unterminated env schema)*

------
https://chatgpt.com/codex/tasks/task_e_68d6afdafe6c8324a00687ae407e0b57