### PR TITLE
docs: atualizar guias de antivírus para conexão via clamd

### DIFF
--- a/docs/security/antivirus-scanning.md
+++ b/docs/security/antivirus-scanning.md
@@ -1,49 +1,51 @@
 # Escaneamento Antivírus de Anexos
 
-Este runbook descreve como operar o serviço de antivírus integrado ao módulo de anexos. Todo arquivo enviado passa por uma varredura ClamAV antes de ser persistido no storage. Resultados, assinaturas e mensagens do scanner são registrados no banco e expostos na API para auditoria.
+Este runbook descreve como operar o serviço de antivírus integrado ao módulo de anexos. Todo arquivo enviado passa por uma varredura ClamAV antes de ser persistido no storage. A API comunica-se diretamente com o daemon `clamd` via socket TCP (porta 3310) usando o comando [`INSTREAM`](https://docs.clamav.net/manual/Usage/Scanning.html#instream). Resultados, assinaturas e mensagens do scanner são registrados no banco e expostos na API para auditoria.
 
 ## Provisionamento do serviço
 
-1. Suba um serviço compatível com ClamAV exposto via HTTP (por exemplo [`clamav-rest`](https://github.com/solita/clamav-rest) ou a imagem `mkodockx/docker-clamav:alpine`).
-2. Publique o endpoint `/scan` aceitando `POST` com o corpo binário do arquivo e respondendo JSON no formato:
-   ```json
-   {
-     "status": "clean" | "infected" | "error",
-     "signature": "Win.Test.EICAR",
-     "message": "EICAR test file detected"
-   }
+1. Suba um serviço com o daemon `clamd` exposto na porta 3310. Um exemplo simples usando Docker Compose:
+   ```yaml
+   services:
+     clamav:
+       image: clamav/clamav:latest
+       ports:
+         - "3310:3310"
+       healthcheck:
+         test: ["CMD", "bash", "-c", "printf 'PING\n' | nc 127.0.0.1 3310 | grep PONG"]
+         interval: 30s
+         timeout: 10s
+         retries: 5
    ```
-   > Qualquer payload desconhecido é tratado como falha e registrado com status `error`.
+2. Garanta conectividade TCP entre a API e o `clamd` (rede interna ou security group permitindo a porta 3310).
 3. Configure as variáveis de ambiente na API:
 
-   | Variável                 | Descrição                                                      | Default    |
-   | ----------------------- | -------------------------------------------------------------- | ---------- |
-   | `ANTIVIRUS_HOST`        | Hostname ou IP onde o serviço está exposto.                    | `localhost` |
-   | `ANTIVIRUS_PORT`        | Porta HTTP do serviço.                                         | `8080`      |
-   | `ANTIVIRUS_PROTOCOL`    | Protocolo (`http` ou `https`).                                 | `http`      |
-   | `ANTIVIRUS_SCAN_PATH`   | Caminho da rota de varredura (ex.: `/scan`).                   | `/scan`     |
-   | `ANTIVIRUS_TIMEOUT_MS`  | Timeout em milissegundos para a chamada HTTP.                  | `10000`     |
-   | `ANTIVIRUS_API_KEY`     | Token opcional (Bearer) caso o serviço exija autenticação.     | _vazio_     |
+   | Variável                | Descrição                                                          | Default      |
+   | ----------------------- | ------------------------------------------------------------------ | ------------ |
+   | `ANTIVIRUS_ENABLED`     | Define se a API deve acionar o scanner.                            | `true`       |
+   | `ANTIVIRUS_HOST`        | Hostname ou IP onde o `clamd` está exposto.                        | `localhost`  |
+   | `ANTIVIRUS_PORT`        | Porta TCP do `clamd` para o comando `INSTREAM`.                    | `3310`       |
+   | `ANTIVIRUS_TIMEOUT_MS`  | Timeout em milissegundos para a conexão/streaming com o `clamd`.   | `30000`      |
 
 4. Atualize o `.env` (ou o secret manager correspondente) e redeploy a API.
 
 ## Fluxo de upload
 
 1. O arquivo é validado quanto ao tamanho/MIME (`validateUpload`).
-2. O buffer é enviado ao serviço ClamAV. Enquanto o scanner não responde, o upload fica pendente.
-3. Resultado `infected` gera erro `422` e impede a gravação do arquivo.
-4. Resultados `clean` ou `error` são persistidos junto ao anexo nos campos:
+2. O buffer é transmitido diretamente ao `clamd` usando o comando `INSTREAM` sobre TCP. Enquanto o scanner não responde, o upload fica pendente.
+3. Resposta contendo assinatura (`FOUND`) gera erro `422` e impede a gravação do arquivo.
+4. Resultados `OK` ou falhas na sessão (`ERROR`) são persistidos junto ao anexo nos campos:
    - `antivirus_scan_status`
    - `antivirus_scan_signature`
    - `antivirus_scan_message`
    - `antivirus_scanned_at`
 5. A API devolve o attachment com os metadados acima, permitindo ao front-end sinalizar "Em análise", "Falha no antivírus" ou "Limpo" ao usuário.
 
-> Quando `status = error` o arquivo é armazenado, mas o operador deve avaliar o log (`antivirus_scan_message`) e decidir se reprocessa a fila.
+> Quando o daemon retorna erro de comunicação (`ERROR`) o arquivo é armazenado, mas o operador deve avaliar o log (`antivirus_scan_message`) e decidir se reprocessa a fila.
 
 ## Monitoramento e tratamento de falhas
 
-- **Logs**: entradas `antivirus scan request failed` (warning) e `antivirus scan threw an error` (error) indicam indisponibilidade do serviço.
+- **Logs**: entradas `antivirus scan request failed` (warning) e `antivirus scan threw an error` (error) indicam indisponibilidade ou falha de streaming com o `clamd`.
 - **Consultas SQL úteis**:
   ```sql
   select id, file_name, antivirus_scan_status, antivirus_scan_message
@@ -51,12 +53,23 @@ Este runbook descreve como operar o serviço de antivírus integrado ao módulo 
    where antivirus_scan_status = 'error'
    order by antivirus_scanned_at desc nulls last;
   ```
-- **Falsos positivos**: se um arquivo legítimo for sinalizado como `infected`, revalide manualmente com `clamscan`. Caso confirme falso positivo, atualize as definições do ClamAV (`freshclam`) e reenvie o arquivo.
-- **Reprocessamento manual**: para reapontar anexos com status `error`, execute um job em lote que leia os buffers do storage e reenvie para o serviço. Atualize os campos `antivirus_*` com o novo resultado via script administrativo.
+- **Falsos positivos**: se um arquivo legítimo for sinalizado como infectado, revalide manualmente com `clamscan`. Caso confirme falso positivo, atualize as definições do ClamAV (`freshclam`) e reenvie o arquivo.
+- **Reprocessamento manual**: para reapontar anexos com status `error`, execute um job em lote que leia os buffers do storage e reenvie via socket TCP para o `clamd`. Atualize os campos `antivirus_*` com o novo resultado via script administrativo.
 
 ## Considerações operacionais
 
-- Mantenha o serviço ClamAV com atualizações automáticas (`freshclam`) e health-check exposto (por exemplo `GET /` retornando `pong`).
+- Mantenha o serviço ClamAV com atualizações automáticas (`freshclam`) e um health-check que envie `PING` para o `clamd`.
 - Configure alertas quando houver mais de _N_ anexos com `antivirus_scan_status = 'error'` em um intervalo de 15 minutos (indicativo de indisponibilidade do scanner).
-- Garanta que filas ou workers que façam pós-processamento de anexos leiam os campos de status e evitem publicar arquivos marcados como `infected`.
+- Garanta que filas ou workers que façam pós-processamento de anexos leiam os campos de status e evitem publicar arquivos marcados como infectados.
 - Documente na central de atendimento que erros de antivírus aparecem para o usuário final como "Verificação do arquivo falhou" com detalhes adicionais recuperados de `antivirus_scan_message`.
+
+## Teste recomendado
+
+1. Faça o deploy do `clamd` conforme o exemplo acima e aguarde o health-check ficar `healthy`.
+2. Gere o arquivo de teste EICAR (`curl -o /tmp/eicar.com https://secure.eicar.org/eicar.com.txt`).
+3. A partir do host da API, execute:
+   ```bash
+   clamdscan --stream /tmp/eicar.com
+   ```
+   O comando transmite o arquivo via `INSTREAM` para o `clamd`. A saída deve conter `FOUND`, confirmando a detecção e validando a conectividade TCP.
+4. Faça um upload pela aplicação do arquivo EICAR e verifique se o anexo é bloqueado com status `infected`.

--- a/docs/security/antivirus.md
+++ b/docs/security/antivirus.md
@@ -1,50 +1,61 @@
 # Serviço de Antivírus para Anexos
 
-Este runbook descreve como provisionar e operar o serviço de verificação de malware utilizado pelo backend. Todas as cargas de anexo passam por uma varredura ClamAV (ou compatível) antes de serem persistidas.
+Este runbook descreve como provisionar e operar o serviço de verificação de malware utilizado pelo backend. Todas as cargas de anexo passam por uma varredura ClamAV antes de serem persistidas. A API estabelece conexão direta via TCP com o daemon `clamd` (porta 3310) e envia os arquivos com o comando [`INSTREAM`](https://docs.clamav.net/manual/Usage/Scanning.html#instream).
 
 ## Provisionamento do serviço
 
 1. **Infraestrutura**
-   - Disponibilize um serviço HTTP com ClamAV exposto (ex.: `clamav-rest` ou `clamdscan` encapsulado em API).
-   - Garanta acesso interno seguro (VPC/VNet) entre a task ECS e o serviço.
-   - Configure autenticação via API key quando disponível.
+   - Disponibilize um daemon `clamd` acessível na rede interna (porta TCP 3310).
+   - Um exemplo com Docker Compose:
+     ```yaml
+     services:
+       clamav:
+         image: clamav/clamav:latest
+         ports:
+           - "3310:3310"
+         healthcheck:
+           test: ["CMD", "bash", "-c", "printf 'PING\n' | nc 127.0.0.1 3310 | grep PONG"]
+           interval: 30s
+           timeout: 10s
+           retries: 5
+     ```
+   - Garanta que `freshclam` esteja habilitado para manter as definições atualizadas.
 2. **Variáveis de ambiente**
    - Defina as seguintes chaves no ECS/Compose ou `.env`:
-     - `ANTIVIRUS_HOST`: hostname ou IP do serviço.
-     - `ANTIVIRUS_PORT`: porta HTTP/HTTPS (padrão `3310`).
-     - `ANTIVIRUS_TLS`: `true` para HTTPS, `false` para HTTP.
-     - `ANTIVIRUS_PATH`: rota que recebe `POST` com o arquivo (padrão `/scan`).
-     - `ANTIVIRUS_API_KEY`: chave compartilhada (opcional).
-     - `ANTIVIRUS_TIMEOUT_MS`: tempo limite da requisição (padrão `10000`).
-     - `ANTIVIRUS_ALLOW_ON_ERROR`: defina `true` apenas se uploads devam ser aceitos quando o serviço estiver indisponível (padrão `false`, bloqueando o envio para falha segura).
+
+     | Variável                | Descrição                                                          | Default      |
+     | ----------------------- | ------------------------------------------------------------------ | ------------ |
+     | `ANTIVIRUS_ENABLED`     | Ativa/desativa a integração com o `clamd`.                         | `true`       |
+     | `ANTIVIRUS_HOST`        | Hostname ou IP do serviço `clamd`.                                 | `localhost`  |
+     | `ANTIVIRUS_PORT`        | Porta TCP usada para o comando `INSTREAM`.                         | `3310`       |
+     | `ANTIVIRUS_TIMEOUT_MS`  | Tempo limite (ms) para conectar e transmitir o arquivo ao daemon.  | `30000`      |
 3. **Saúde**
-   - Execute um teste com `curl` enviando um arquivo de controle (`clam.eicar`) e valide o retorno `infected` (HTTP 200).
-   - Configure monitoramento da latência/erros do endpoint.
+   - Configure monitoramento que execute `printf 'PING\n' | nc $HOST $PORT` e espere `PONG`.
+   - Teste fim a fim com `clamdscan --stream /tmp/eicar.com` a partir do mesmo host da API e valide a resposta `FOUND`.
 
 ## Fluxo de varredura
 
 1. O endpoint `/files` valida tamanho/MIME e calcula `checksum` SHA-256.
-2. Antes de salvar o arquivo, envia o payload codificado em base64 ao serviço de antivírus.
-3. Respostas possíveis:
-   - `clean`: upload concluído. Metadados `scanStatus=clean`, `scanSignature` e `scanCompletedAt` são persistidos e expostos em `GET /attachments`.
-   - `pending`: serviço asincrônico. O status é registrado como `pending` e exibido ao usuário até a retentativa manual.
-   - `infected`: upload rejeitado com HTTP 422. Nenhum dado é gravado.
-   - `failed`: erro de comunicação/processamento. Por padrão o upload é bloqueado (503) — pode ser flexibilizado com `ANTIVIRUS_ALLOW_ON_ERROR=true`.
-   - `skipped`: scanner desabilitado. O timestamp de auditoria é registrado mesmo sem análise.
+2. Antes de salvar o arquivo, abre um socket TCP para o `clamd` e envia o conteúdo com `INSTREAM`.
+3. Respostas possíveis do daemon:
+   - `stream: OK`: upload concluído. Metadados `scanStatus=clean`, `scanSignature` e `scanCompletedAt` são persistidos e expostos em `GET /attachments`.
+   - `stream: <signature> FOUND`: upload rejeitado com HTTP 422. Nenhum dado é gravado.
+   - `stream: ERROR` ou timeout: erro de comunicação/processamento. Por padrão o upload é bloqueado (503) para falha segura.
+   - Integração desabilitada (`ANTIVIRUS_ENABLED=false`): o upload segue, porém os campos de auditoria são preenchidos com `skipped`.
 4. Os metadados são usados em auditoria (consumidos por DSR e relatórios) para rastrear varreduras.
 
 ## Operação e tratamento de falsos positivos
 
-- **Análises pendentes**: investigue a fila do serviço e reenvie manualmente se necessário. Atualize o registro pela API do scanner para concluir (`scanStatus=clean`).
-- **Falsos positivos**: registre o incidente, atualize assinaturas ClamAV e repita a varredura. Somente após resultado `clean` reabra o upload para o usuário.
-- **Falhas do serviço**: monitore logs do backend (`antivirus scan request failed`) e acione o time de infra. Caso seja imprescindível manter uploads, altere temporariamente `ANTIVIRUS_ALLOW_ON_ERROR=true`, documentando o período de exceção.
-- **Auditoria**: utilize `attachments.scan_*` para comprovar horário, engine e assinatura da varredura em auditorias LGPD.
+- **Análises pendentes**: investigue logs e conectividade TCP com o `clamd` (`nc -vz host 3310`). Restaure o serviço antes de liberar novos uploads.
+- **Falsos positivos**: registre o incidente, atualize assinaturas ClamAV (`freshclam`) e repita a varredura com `clamdscan --stream`. Somente após resultado `OK` reabra o upload para o usuário.
+- **Falhas do serviço**: monitore logs do backend (`antivirus scan request failed`) e acione o time de infra. Documente períodos em que `ANTIVIRUS_ENABLED` precise ser temporariamente desativado.
+- **Auditoria**: utilize `attachments.antivirus_*` para comprovar horário, engine e assinatura da varredura em auditorias LGPD.
 
 ## Troubleshooting rápido
 
 | Sintoma | Ação sugerida |
 | --- | --- |
-| Upload retorna 503 | Verifique conectividade com o serviço, status HTTP, e se o timeout está adequado. |
-| Upload marcado como `pending` indefinidamente | Verifique filas internas do serviço de antivírus e reexecute a varredura. |
-| Falha de parse no log `failed to parse antivirus response` | Ajuste o formato da API para retornar JSON válido com campo `status`. |
-| Usuário reporta falso positivo | Atualize assinaturas, execute `freshclam`, force nova varredura e comunique auditoria. |
+| Upload retorna 503 | Verifique conectividade TCP, se o `clamd` responde `PONG` e o timeout configurado. |
+| Upload marcado como `pending` indefinidamente | Reenvie o arquivo manualmente com `clamdscan --stream` e valide se o daemon responde. |
+| Falha de parse no log `failed to parse antivirus response` | Garanta que o `clamd` retorne as linhas padrão `stream: OK/FOUND/ERROR`. |
+| Usuário reporta falso positivo | Atualize assinaturas (`freshclam`), execute nova varredura manual e comunique auditoria. |


### PR DESCRIPTION
## Summary
- document the direct TCP `clamd` integration via the INSTREAM command
- update environment variable references to match the socket-based configuration
- add deployment, health-check, and test guidance aligned with the TCP workflow

## Testing
- not run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_68d6b2c3dca48324ad819c85bc734eb5