### PR TITLE
refactor: centralize env parsing

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,11 +19,21 @@ const envSchema = z.object({
   JWT_EXPIRES_IN: z.string().default('1d'),
   REDIS_URL: z.string().url().optional(),
   CACHE_TTL_SECONDS: z.string().regex(/^[0-9]+$/).default('300'),
+  RATE_LIMIT_MAX: z.string().regex(/^\d+$/).default('200'),
+  RATE_LIMIT_TIME_WINDOW_MS: z.string().regex(/^\d+$/).default('60000'),
+  ATTACHMENTS_STORAGE: z.enum(['filesystem', 's3']).default('filesystem'),
   UPLOADS_DIR: z.string().default('tmp/uploads'),
   ANTIVIRUS_ENABLED: z.enum(['true', 'false']).default('true'),
   ANTIVIRUS_HOST: z.string().default('localhost'),
   ANTIVIRUS_PORT: z.string().regex(/^\d+$/).default('3310'),
   ANTIVIRUS_TIMEOUT_MS: z.string().regex(/^\d+$/).default('30000'),
+  S3_BUCKET: z.string().optional(),
+  S3_REGION: z.string().default('us-east-1'),
+  S3_ENDPOINT: z.string().url().optional(),
+  S3_FORCE_PATH_STYLE: z.enum(['true', 'false']).default('false'),
+  S3_ACCESS_KEY_ID: z.string().optional(),
+  S3_SECRET_ACCESS_KEY: z.string().optional(),
+  S3_SERVER_SIDE_ENCRYPTION: z.enum(['AES256', 'aws:kms']).optional(),
   NOTIFICATIONS_EMAIL_FROM: z.string().email().default('alerts@imm.local'),
   NOTIFICATIONS_EMAIL_SES_REGION: z.string().default('us-east-1'),
   NOTIFICATIONS_EMAIL_SES_ACCESS_KEY_ID: z.string().optional(),
@@ -52,3 +62,32 @@ const envSchema = z.object({
   PII_ENCRYPTION_KMS_KEY_ID: z.string().optional(),
   PII_ENCRYPTION_CACHE_TTL_SECONDS: z.string().regex(/^[0-9]+$/).default('300'),
   AUDIT_LOG_SIGNING_KEY: z.string().min(32).optional(),
+  DATA_RETENTION_DAYS: z.string().regex(/^[0-9]+$/).default('365'),
+  DATA_RETENTION_ANONYMIZE_DAYS: z.string().regex(/^[0-9]+$/).default('180'),
+  CONSENT_REVIEW_INTERVAL_DAYS: z.string().regex(/^[0-9]+$/).default('365'),
+  CONSENT_REVIEW_NOTIFICATION_COOLDOWN_DAYS: z.string().regex(/^[0-9]+$/).default('30'),
+  FORM_VERIFICATION_HASH_SECRET: z.string().optional(),
+  FORM_VERIFICATION_BASE_URL: z.string().url().optional(),
+  MFA_TOTP_ISSUER: z.string().default('MoveOn GS'),
+  MFA_LOGIN_CHALLENGE_TTL_SECONDS: z.string().regex(/^[0-9]+$/).default('300'),
+  WEBAUTHN_RP_ID: z.string().default('localhost'),
+  WEBAUTHN_RP_NAME: z.string().default('MoveOn GS'),
+  WEBAUTHN_RP_ORIGIN: z.string().url().default('http://localhost:3000'),
+});
+
+type Env = z.infer<typeof envSchema>;
+
+let cachedEnv: Env | null = null;
+
+function loadEnv(): Env {
+  if (!cachedEnv) {
+    cachedEnv = envSchema.parse(process.env);
+  }
+  return cachedEnv;
+}
+
+export const env = loadEnv();
+
+export function getEnv(): Env {
+  return env;
+}

--- a/src/modules/attachments/antivirus.ts
+++ b/src/modules/attachments/antivirus.ts
@@ -1,7 +1,7 @@
 import { createConnection } from 'net';
 import { promisify } from 'util';
 import { readFile } from 'fs/promises';
-import { env } from '../../config/env';
+import { getEnv } from '../../config/env';
 import { logger } from '../../observability/logger';
 
 interface ScanResult {
@@ -25,12 +25,14 @@ export class AntivirusScanner {
   private readonly timeoutMs: number;
 
   constructor() {
+    const env = getEnv();
     this.host = env.ANTIVIRUS_HOST;
     this.port = parseInt(env.ANTIVIRUS_PORT, 10);
     this.timeoutMs = parseInt(env.ANTIVIRUS_TIMEOUT_MS, 10);
   }
 
   async scanFile(filePath: string): Promise<ScanResult> {
+    const env = getEnv();
     if (env.ANTIVIRUS_ENABLED !== 'true') {
       logger.debug('Antivirus scanning is disabled');
       return { isInfected: false, viruses: [] };
@@ -46,6 +48,7 @@ export class AntivirusScanner {
   }
 
   async scanBuffer(buffer: Buffer): Promise<ScanResult> {
+    const env = getEnv();
     if (env.ANTIVIRUS_ENABLED !== 'true') {
       logger.debug('Antivirus scanning is disabled');
       return { isInfected: false, viruses: [] };
@@ -122,6 +125,7 @@ export class AntivirusScanner {
   }
 
   async testConnection(): Promise<boolean> {
+    const env = getEnv();
     if (env.ANTIVIRUS_ENABLED !== 'true') {
       logger.debug('Antivirus scanning is disabled');
       return true;

--- a/src/modules/attachments/service.ts
+++ b/src/modules/attachments/service.ts
@@ -1,6 +1,5 @@
 import { FastifyInstance } from 'fastify';
 import { randomUUID } from 'node:crypto';
-import { env } from '../../config/env';
 import { logger } from '../../observability/logger';
 import { attachmentsRepository } from './repository';
 import { antivirusScanner } from './antivirus';


### PR DESCRIPTION
## Summary
- parse and cache environment variables through a normalized helper
- broaden the env schema with storage, retention, consent, MFA and WebAuthn settings
- point attachment utilities to the new environment exports

## Testing
- npm run check *(fails: existing TypeScript errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6e8c368832490e3afee13e3e5f3